### PR TITLE
feat: add payload-based execution methods for various channels

### DIFF
--- a/crates/gproxy-core/src/routes/provider.rs
+++ b/crates/gproxy-core/src/routes/provider.rs
@@ -11,7 +11,7 @@ use axum::routing::{get, post};
 use futures_util::Stream;
 use gproxy_middleware::{
     MiddlewareTransformError, OperationFamily, ProtocolKind, TransformRequest,
-    TransformResponsePayload, UsageSnapshot, attach_usage_extractor,
+    TransformRequestPayload, TransformResponsePayload, UsageSnapshot, attach_usage_extractor,
 };
 use gproxy_protocol::claude::count_tokens::request as claude_count_tokens_request;
 use gproxy_protocol::claude::count_tokens::response as claude_count_tokens_response;
@@ -41,10 +41,11 @@ use serde_json::json;
 use tokio::sync::mpsc;
 
 use gproxy_provider::{
-    BuiltinChannel, ChannelId, CredentialRef, ProviderDefinition, RouteImplementation, RouteKey,
-    TokenizerResolutionContext, TrackedHttpEvent, UpstreamCredentialUpdate, UpstreamError,
-    UpstreamOAuthResponse, UpstreamRequestMeta, UpstreamResponse, capture_tracked_http_events,
-    credential_kind_for_storage, parse_query_value, try_local_response_for_channel,
+    BuiltinChannel, ChannelId, CredentialRef, ProviderDefinition, RetryWithPayloadRequest,
+    RouteImplementation, RouteKey, TokenizerResolutionContext, TrackedHttpEvent,
+    UpstreamCredentialUpdate, UpstreamError, UpstreamOAuthResponse, UpstreamRequestMeta,
+    UpstreamResponse, capture_tracked_http_events, credential_kind_for_storage, parse_query_value,
+    try_local_response_for_channel,
 };
 use gproxy_storage::{
     CredentialQuery, CredentialStatusWrite, CredentialWrite, ProviderQuery, ProviderWrite, Scope,
@@ -109,13 +110,31 @@ struct RequestAuthContext {
     downstream_trace_id: Option<i64>,
 }
 
+#[derive(Debug, Clone)]
+struct UsageRequestContext {
+    operation: OperationFamily,
+    protocol: ProtocolKind,
+    model: Option<String>,
+    body_for_estimate: Option<Vec<u8>>,
+}
+
+impl UsageRequestContext {
+    const fn operation(&self) -> OperationFamily {
+        self.operation
+    }
+
+    const fn protocol(&self) -> ProtocolKind {
+        self.protocol
+    }
+}
+
 #[derive(Clone)]
 struct UpstreamStreamRecordContext {
     state: Arc<AppState>,
     channel: ChannelId,
     provider: ProviderDefinition,
     auth: RequestAuthContext,
-    request: TransformRequest,
+    request: UsageRequestContext,
     provider_id: Option<i64>,
     credential_id: Option<i64>,
     request_meta: Option<UpstreamRequestMeta>,

--- a/crates/gproxy-core/src/routes/provider/execute.rs
+++ b/crates/gproxy-core/src/routes/provider/execute.rs
@@ -1,18 +1,21 @@
 use super::{
     AppState, Arc, Body, BuiltinChannel, Bytes, ChannelId, HttpError, MiddlewareTransformError,
     OperationFamily, ProtocolKind, ProviderDefinition, RequestAuthContext, Response,
-    RouteImplementation, RouteKey, SseToNdjsonRewriter, StatusCode, Stream,
-    TokenizerResolutionContext, TransformRequest, TransformResponsePayload,
-    UpstreamAndUsageEventInput, UpstreamError, UpstreamResponse, UpstreamStreamRecordContext,
-    UpstreamStreamRecordGuard, apply_credential_update_and_persist, attach_usage_extractor,
-    capture_tracked_http_events, claude_count_tokens_response, decode_response_for_usage,
-    enqueue_credential_status_updates_for_request, enqueue_internal_tracked_http_events,
-    enqueue_upstream_and_usage_event, gemini_count_tokens_response, is_wrapped_stream_channel,
-    json, mpsc, ndjson_chunk_to_sse_chunk, normalize_upstream_response_body_for_channel,
+    RetryWithPayloadRequest, RouteImplementation, RouteKey, SseToNdjsonRewriter, StatusCode,
+    Stream, TokenizerResolutionContext, TransformRequest, TransformRequestPayload,
+    TransformResponsePayload, UpstreamAndUsageEventInput, UpstreamError, UpstreamResponse,
+    UpstreamStreamRecordContext, UpstreamStreamRecordGuard, apply_credential_update_and_persist,
+    attach_usage_extractor, capture_tracked_http_events, claude_count_tokens_response,
+    decode_response_for_usage, enqueue_credential_status_updates_for_request,
+    enqueue_internal_tracked_http_events, enqueue_upstream_and_usage_event,
+    enqueue_upstream_request_event_from_meta, gemini_count_tokens_response,
+    is_wrapped_stream_channel, json, mpsc, ndjson_chunk_to_sse_chunk,
+    normalize_upstream_response_body_for_channel,
     normalize_upstream_stream_ndjson_chunk_for_channel, now_unix_ms, openai_count_tokens_request,
     openai_count_tokens_response, resolve_provider_id, response_headers_to_pairs,
     try_local_response_for_channel, upstream_error_credential_id, upstream_error_request_meta,
-    upstream_error_status,
+    upstream_error_status, usage_request_context_from_payload,
+    usage_request_context_from_transform_request,
 };
 use futures_util::StreamExt;
 
@@ -569,6 +572,8 @@ pub(super) async fn execute_transform_request(
 ) -> Result<Response, UpstreamError> {
     let downstream_request = request;
     let mut upstream_request = downstream_request.clone();
+    let downstream_request_context =
+        usage_request_context_from_transform_request(&downstream_request);
     let mut dispatch_route = None;
     let mut dispatch_local = false;
     let provider_id = resolve_provider_id(state.as_ref(), &channel).await.ok();
@@ -581,7 +586,7 @@ pub(super) async fn execute_transform_request(
             state.as_ref(),
             UpstreamAndUsageEventInput {
                 auth,
-                request: &downstream_request,
+                request: &downstream_request_context,
                 provider_id,
                 credential_id: None,
                 request_meta: None,
@@ -605,7 +610,9 @@ pub(super) async fn execute_transform_request(
                 dst_operation: destination.operation,
                 dst_protocol: destination.protocol,
             };
-            if !route.is_passthrough() {
+            if gproxy_middleware::select_request_lane(route)
+                == gproxy_middleware::TransformLane::Typed
+            {
                 match gproxy_middleware::transform_request(downstream_request.clone(), route) {
                     Ok(transformed) => {
                         upstream_request = transformed;
@@ -616,7 +623,7 @@ pub(super) async fn execute_transform_request(
                             state.as_ref(),
                             UpstreamAndUsageEventInput {
                                 auth,
-                                request: &downstream_request,
+                                request: &downstream_request_context,
                                 provider_id,
                                 credential_id: None,
                                 request_meta: None,
@@ -642,7 +649,7 @@ pub(super) async fn execute_transform_request(
                 state.as_ref(),
                 UpstreamAndUsageEventInput {
                     auth,
-                    request: &downstream_request,
+                    request: &downstream_request_context,
                     provider_id,
                     credential_id: None,
                     request_meta: None,
@@ -660,6 +667,7 @@ pub(super) async fn execute_transform_request(
 
     let now = now_unix_ms();
     ensure_stream_usage_option_on_native_chat(&mut upstream_request);
+    let upstream_request_context = usage_request_context_from_transform_request(&upstream_request);
     let (upstream_result, tracked_http_events) = if dispatch_local {
         (
             execute_local_request(state.as_ref(), &channel, &downstream_request).await,
@@ -715,7 +723,7 @@ pub(super) async fn execute_transform_request(
                 state.as_ref(),
                 UpstreamAndUsageEventInput {
                     auth,
-                    request: &downstream_request,
+                    request: &downstream_request_context,
                     provider_id,
                     credential_id: err_credential_id,
                     request_meta: err_request_meta.as_ref(),
@@ -756,7 +764,10 @@ pub(super) async fn execute_transform_request(
 
     if let Some(mut local) = upstream.local_response {
         let usage_source_response = local.clone();
-        if let Some(route) = dispatch_route.filter(|item| !item.is_passthrough()) {
+        if let Some(route) = dispatch_route.filter(|item| {
+            gproxy_middleware::select_response_lane(*item)
+                == gproxy_middleware::TransformLane::Typed
+        }) {
             local = gproxy_middleware::transform_response(local, route)
                 .map_err(|err| UpstreamError::SerializeRequest(err.to_string()))?;
         }
@@ -764,7 +775,7 @@ pub(super) async fn execute_transform_request(
             state.as_ref(),
             UpstreamAndUsageEventInput {
                 auth,
-                request: &upstream_request,
+                request: &upstream_request_context,
                 provider_id,
                 credential_id: upstream_credential_id,
                 request_meta: upstream_request_meta.as_ref(),
@@ -788,14 +799,17 @@ pub(super) async fn execute_transform_request(
     if let Some(response) = upstream.response {
         let response_status = response.status().as_u16();
         let response_headers = response_headers_to_pairs(&response);
-        if let Some(route) = dispatch_route.filter(|item| !item.is_passthrough()) {
+        if let Some(route) = dispatch_route.filter(|item| {
+            gproxy_middleware::select_response_lane(*item)
+                == gproxy_middleware::TransformLane::Typed
+        }) {
             if !response.status().is_success() {
                 let stream_record_context = UpstreamStreamRecordContext {
                     state: state.clone(),
                     channel: channel.clone(),
                     provider: provider.clone(),
                     auth,
-                    request: upstream_request.clone(),
+                    request: upstream_request_context.clone(),
                     provider_id,
                     credential_id: upstream_credential_id,
                     request_meta: upstream_request_meta.clone(),
@@ -897,7 +911,7 @@ pub(super) async fn execute_transform_request(
                     channel: channel.clone(),
                     provider: provider.clone(),
                     auth,
-                    request: upstream_request.clone(),
+                    request: upstream_request_context.clone(),
                     provider_id,
                     credential_id: upstream_credential_id,
                     request_meta: upstream_request_meta.clone(),
@@ -942,7 +956,7 @@ pub(super) async fn execute_transform_request(
                     state.as_ref(),
                     UpstreamAndUsageEventInput {
                         auth,
-                        request: &upstream_request,
+                        request: &upstream_request_context,
                         provider_id,
                         credential_id: upstream_credential_id,
                         request_meta: upstream_request_meta.as_ref(),
@@ -983,7 +997,7 @@ pub(super) async fn execute_transform_request(
                 channel: channel.clone(),
                 provider: provider.clone(),
                 auth,
-                request: upstream_request.clone(),
+                request: upstream_request_context.clone(),
                 provider_id,
                 credential_id: upstream_credential_id,
                 request_meta: upstream_request_meta.clone(),
@@ -1034,7 +1048,7 @@ pub(super) async fn execute_transform_request(
             state.as_ref(),
             UpstreamAndUsageEventInput {
                 auth,
-                request: &upstream_request,
+                request: &upstream_request_context,
                 provider_id,
                 credential_id: upstream_credential_id,
                 request_meta: upstream_request_meta.as_ref(),
@@ -1061,7 +1075,7 @@ pub(super) async fn execute_transform_request(
         state.as_ref(),
         UpstreamAndUsageEventInput {
             auth,
-            request: &upstream_request,
+            request: &upstream_request_context,
             provider_id,
             credential_id: upstream_credential_id,
             request_meta: upstream_request_meta.as_ref(),
@@ -1076,6 +1090,319 @@ pub(super) async fn execute_transform_request(
     Err(UpstreamError::UpstreamRequest(
         "upstream returned empty response".to_string(),
     ))
+}
+
+async fn collect_request_payload_body_bytes(
+    request: TransformRequestPayload,
+) -> Result<(OperationFamily, ProtocolKind, Vec<u8>), UpstreamError> {
+    let mut out = Vec::new();
+    let mut body = request.body;
+    while let Some(item) = body.next().await {
+        let chunk = item.map_err(|err| UpstreamError::SerializeRequest(err.to_string()))?;
+        out.extend_from_slice(chunk.as_ref());
+    }
+    Ok((request.operation, request.protocol, out))
+}
+
+pub(super) fn shape_passthrough_request(
+    _channel: &ChannelId,
+    _operation: OperationFamily,
+    _protocol: ProtocolKind,
+    body_bytes: Vec<u8>,
+) -> Vec<u8> {
+    body_bytes
+}
+
+pub(super) fn shape_passthrough_response(
+    channel: &ChannelId,
+    _operation: OperationFamily,
+    _protocol: ProtocolKind,
+    _status: StatusCode,
+    headers: &[(String, String)],
+    body_bytes: Vec<u8>,
+) -> (Vec<(String, String)>, Vec<u8>) {
+    let normalized_body =
+        normalize_upstream_response_body_for_channel(channel, body_bytes.as_ref())
+            .unwrap_or_else(|| body_bytes.clone());
+    let mut normalized_headers = headers.to_vec();
+    if normalized_body != body_bytes {
+        remove_header_ignore_case(&mut normalized_headers, "content-length");
+    }
+    (normalized_headers, normalized_body)
+}
+
+async fn execute_passthrough_payload_request(
+    state: Arc<AppState>,
+    channel: ChannelId,
+    provider: ProviderDefinition,
+    auth: RequestAuthContext,
+    request: TransformRequestPayload,
+) -> Result<Response, UpstreamError> {
+    let (operation, protocol, request_bytes) = collect_request_payload_body_bytes(request).await?;
+    let request_bytes = shape_passthrough_request(&channel, operation, protocol, request_bytes);
+    let request_context =
+        usage_request_context_from_payload(operation, protocol, request_bytes.as_slice());
+    let provider_id = resolve_provider_id(state.as_ref(), &channel).await.ok();
+    let now = now_unix_ms();
+    let http = state.load_http();
+    let spoof_http = matches!(&channel, ChannelId::Builtin(BuiltinChannel::ClaudeCode))
+        .then(|| state.load_spoof_http());
+    let tokenizers = state.tokenizers();
+    let global = state.config.load().global.clone();
+
+    let (upstream_result, tracked_http_events) = capture_tracked_http_events(async {
+        provider
+            .execute_payload_with_retry_with_spoof(
+                http.as_ref(),
+                spoof_http.as_deref(),
+                &state.credential_states,
+                RetryWithPayloadRequest {
+                    operation,
+                    protocol,
+                    body: request_bytes.as_slice(),
+                    now_unix_ms: now,
+                    token_resolution: TokenizerResolutionContext {
+                        tokenizer_store: tokenizers.as_ref(),
+                        hf_token: global.hf_token.as_deref(),
+                        hf_url: global.hf_url.as_deref(),
+                    },
+                },
+            )
+            .await
+    })
+    .await;
+
+    enqueue_credential_status_updates_for_request(state.as_ref(), &channel, &provider, now).await;
+
+    let upstream = match upstream_result {
+        Ok(value) => value,
+        Err(err) => {
+            let err_request_meta = upstream_error_request_meta(&err);
+            let err_credential_id = upstream_error_credential_id(&err);
+            let err_status = upstream_error_status(&err);
+            enqueue_internal_tracked_http_events(
+                state.as_ref(),
+                auth.downstream_trace_id,
+                provider_id,
+                err_credential_id,
+                tracked_http_events.as_slice(),
+                err_request_meta.as_ref(),
+            )
+            .await;
+            enqueue_upstream_request_event_from_meta(
+                state.as_ref(),
+                auth.downstream_trace_id,
+                provider_id,
+                err_credential_id,
+                err_request_meta.as_ref(),
+                super::UpstreamResponseMeta {
+                    status: err_status,
+                    headers: &[],
+                    body: None,
+                },
+            )
+            .await;
+            return Err(err);
+        }
+    };
+
+    let upstream_credential_id = upstream.credential_id;
+    let upstream_request_meta = upstream.request_meta.clone();
+    enqueue_internal_tracked_http_events(
+        state.as_ref(),
+        auth.downstream_trace_id,
+        provider_id,
+        upstream_credential_id,
+        tracked_http_events.as_slice(),
+        upstream_request_meta.as_ref(),
+    )
+    .await;
+
+    if let Some(update) = upstream.credential_update.clone() {
+        apply_credential_update_and_persist(
+            state.clone(),
+            channel.clone(),
+            provider.clone(),
+            update,
+        )
+        .await;
+    }
+
+    if let Some(local) = upstream.local_response {
+        let body = serialize_local_response_body(&local)?;
+        enqueue_upstream_and_usage_event(
+            state.as_ref(),
+            UpstreamAndUsageEventInput {
+                auth,
+                request: &request_context,
+                provider_id,
+                credential_id: upstream_credential_id,
+                request_meta: upstream_request_meta.as_ref(),
+                error_status: None,
+                response_status: Some(200),
+                response_headers: &[("content-type".to_string(), "application/json".to_string())],
+                response_body: None,
+                local_response: Some(&local),
+            },
+        )
+        .await;
+        let response = Response::builder()
+            .status(StatusCode::OK)
+            .header("content-type", "application/json")
+            .body(Body::from(body))
+            .map_err(|err| UpstreamError::SerializeRequest(err.to_string()))?;
+        return Ok(response);
+    }
+
+    if let Some(response) = upstream.response {
+        let response_status = response.status().as_u16();
+        let response_headers = response_headers_to_pairs(&response);
+        if operation == OperationFamily::StreamGenerateContent
+            || is_streaming_content_type(response_headers.as_slice())
+        {
+            let rewrite_gemini_stream_to_ndjson = operation
+                == OperationFamily::StreamGenerateContent
+                && protocol == ProtocolKind::GeminiNDJson;
+            let stream_record_context = UpstreamStreamRecordContext {
+                state: state.clone(),
+                channel: channel.clone(),
+                provider: provider.clone(),
+                auth,
+                request: request_context.clone(),
+                provider_id,
+                credential_id: upstream_credential_id,
+                request_meta: upstream_request_meta.clone(),
+                response_status: Some(response_status),
+                response_headers: response_headers.clone(),
+                stream_usage: None,
+                record_upstream_event: true,
+                record_stream_usage_event: true,
+            };
+            return upstream_response_to_axum_stream(
+                response,
+                rewrite_gemini_stream_to_ndjson,
+                Some(stream_record_context),
+            );
+        }
+
+        let status =
+            StatusCode::from_u16(response.status().as_u16()).unwrap_or(StatusCode::BAD_GATEWAY);
+        let headers = response
+            .headers()
+            .iter()
+            .filter_map(|(name, value)| {
+                value
+                    .to_str()
+                    .ok()
+                    .map(|value| (name.as_str().to_string(), value.to_string()))
+            })
+            .collect::<Vec<_>>();
+        let body_bytes = response
+            .bytes()
+            .await
+            .map_err(|err| UpstreamError::UpstreamRequest(err.to_string()))?;
+        let raw_body = body_bytes.to_vec();
+        let (headers_for_client, normalized_body) = shape_passthrough_response(
+            &channel,
+            operation,
+            protocol,
+            status,
+            headers.as_slice(),
+            raw_body.clone(),
+        );
+        let encoded_for_usage = encode_http_response_for_transform(
+            status,
+            headers_for_client.as_slice(),
+            normalized_body.as_ref(),
+        )?;
+        let usage_source_response =
+            decode_response_for_usage(operation, protocol, encoded_for_usage.as_ref());
+        enqueue_upstream_and_usage_event(
+            state.as_ref(),
+            UpstreamAndUsageEventInput {
+                auth,
+                request: &request_context,
+                provider_id,
+                credential_id: upstream_credential_id,
+                request_meta: upstream_request_meta.as_ref(),
+                error_status: None,
+                response_status: Some(response_status),
+                response_headers: response_headers.as_slice(),
+                response_body: Some(raw_body.clone()),
+                local_response: usage_source_response.as_ref(),
+            },
+        )
+        .await;
+        return response_from_status_headers_and_bytes(
+            status,
+            headers_for_client.as_slice(),
+            normalized_body,
+        );
+    }
+
+    enqueue_upstream_and_usage_event(
+        state.as_ref(),
+        UpstreamAndUsageEventInput {
+            auth,
+            request: &request_context,
+            provider_id,
+            credential_id: upstream_credential_id,
+            request_meta: upstream_request_meta.as_ref(),
+            error_status: None,
+            response_status: None,
+            response_headers: &[],
+            response_body: None,
+            local_response: None,
+        },
+    )
+    .await;
+    Err(UpstreamError::UpstreamRequest(
+        "upstream returned empty response".to_string(),
+    ))
+}
+
+pub(super) async fn execute_transform_request_payload(
+    state: Arc<AppState>,
+    channel: ChannelId,
+    provider: ProviderDefinition,
+    auth: RequestAuthContext,
+    request: TransformRequestPayload,
+) -> Result<Response, UpstreamError> {
+    let src_route = RouteKey::new(request.operation, request.protocol);
+    let Some(implementation) = provider.dispatch.resolve(src_route).cloned() else {
+        return Err(UpstreamError::UnsupportedRequest);
+    };
+
+    let route = match implementation {
+        RouteImplementation::Passthrough => Some(gproxy_middleware::TransformRoute {
+            src_operation: src_route.operation,
+            src_protocol: src_route.protocol,
+            dst_operation: src_route.operation,
+            dst_protocol: src_route.protocol,
+        }),
+        RouteImplementation::TransformTo { destination } => {
+            Some(gproxy_middleware::TransformRoute {
+                src_operation: src_route.operation,
+                src_protocol: src_route.protocol,
+                dst_operation: destination.operation,
+                dst_protocol: destination.protocol,
+            })
+        }
+        RouteImplementation::Local => None,
+        RouteImplementation::Unsupported => return Err(UpstreamError::UnsupportedRequest),
+    };
+
+    if let Some(route) = route
+        && gproxy_middleware::select_request_lane(route) == gproxy_middleware::TransformLane::Raw
+    {
+        return execute_passthrough_payload_request(state, channel, provider, auth, request).await;
+    }
+
+    let (operation, protocol, request_bytes) = collect_request_payload_body_bytes(request).await?;
+    let decoded =
+        gproxy_middleware::decode_request_payload(operation, protocol, request_bytes.as_slice())
+            .map_err(|err| UpstreamError::SerializeRequest(err.to_string()))?;
+    execute_transform_request(state, channel, provider, auth, decoded).await
 }
 
 pub(super) async fn execute_transform_candidates(

--- a/crates/gproxy-core/src/routes/provider/handlers/claude.rs
+++ b/crates/gproxy-core/src/routes/provider/handlers/claude.rs
@@ -1,44 +1,94 @@
 use std::sync::Arc;
 
-use axum::Json;
+use axum::body::Bytes;
 use axum::extract::{Path, State};
 use axum::http::HeaderMap;
 use axum::response::Response;
-use gproxy_middleware::TransformRequest;
-use gproxy_protocol::claude::count_tokens::request as claude_count_tokens_request;
-use gproxy_protocol::claude::create_message::request as claude_create_message_request;
+use gproxy_middleware::{OperationFamily, ProtocolKind, TransformRequestPayload};
+use serde_json::{Value, json};
 
 use crate::AppState;
 
 use super::super::{
-    HttpError, anthropic_headers_from_request, authorize_provider_access, deserialize_json_scalar,
-    execute_transform_request, resolve_provider, serialize_json_scalar,
+    HttpError, anthropic_headers_from_request, authorize_provider_access, bad_request,
+    execute_transform_request_payload, parse_json_body, resolve_provider,
     split_provider_prefixed_plain_model,
 };
+
+fn required_string_field<'a>(
+    value: &'a Value,
+    pointer: &str,
+    missing_message: &str,
+    invalid_message: &str,
+) -> Result<&'a str, HttpError> {
+    let Some(raw) = value.pointer(pointer) else {
+        return Err(bad_request(missing_message));
+    };
+    raw.as_str().ok_or_else(|| bad_request(invalid_message))
+}
+
+fn set_string_field(
+    value: &mut Value,
+    pointer: &str,
+    new_value: String,
+    missing_message: &str,
+) -> Result<(), HttpError> {
+    let Some(slot) = value.pointer_mut(pointer) else {
+        return Err(bad_request(missing_message));
+    };
+    *slot = Value::String(new_value);
+    Ok(())
+}
+
+fn stream_enabled(value: &Value) -> bool {
+    value
+        .pointer("/stream")
+        .and_then(Value::as_bool)
+        .unwrap_or(false)
+}
+
+fn encode_json_value(value: &Value, context: &str) -> Result<Bytes, HttpError> {
+    serde_json::to_vec(value)
+        .map(Bytes::from)
+        .map_err(|err| bad_request(format!("{context}: {err}")))
+}
+
+fn build_claude_payload(body: Value, headers: Value, context: &str) -> Result<Bytes, HttpError> {
+    encode_json_value(
+        &json!({
+            "headers": headers,
+            "body": body,
+        }),
+        context,
+    )
+}
 
 pub(in crate::routes::provider) async fn claude_messages(
     State(state): State<Arc<AppState>>,
     Path(provider_name): Path<String>,
     headers: HeaderMap,
-    Json(body): Json<claude_create_message_request::RequestBody>,
+    body: Bytes,
 ) -> Result<Response, HttpError> {
     let auth = authorize_provider_access(&headers, &state)?;
     let (channel, provider) = resolve_provider(&state, provider_name.as_str())?;
-    let mut request = claude_create_message_request::ClaudeCreateMessageRequest {
-        body,
-        ..Default::default()
+    let body = parse_json_body::<Value>(&body, "invalid claude messages request body")?;
+    let operation = if stream_enabled(&body) {
+        OperationFamily::StreamGenerateContent
+    } else {
+        OperationFamily::GenerateContent
     };
     let (version, beta) = anthropic_headers_from_request(&headers);
-    request.headers.anthropic_version = version;
-    if beta.is_some() {
-        request.headers.anthropic_beta = beta;
-    }
-    let envelope = if request.body.stream.unwrap_or(false) {
-        TransformRequest::StreamGenerateContentClaude(request)
-    } else {
-        TransformRequest::GenerateContentClaude(request)
-    };
-    execute_transform_request(state, channel, provider, auth, envelope)
+    let payload_body = build_claude_payload(
+        body,
+        json!({
+            "anthropic_version": version,
+            "anthropic_beta": beta,
+        }),
+        "invalid claude messages request body",
+    )?;
+    let payload =
+        TransformRequestPayload::from_bytes(operation, ProtocolKind::Claude, payload_body);
+    execute_transform_request_payload(state, channel, provider, auth, payload)
         .await
         .map_err(HttpError::from)
 }
@@ -46,28 +96,41 @@ pub(in crate::routes::provider) async fn claude_messages(
 pub(in crate::routes::provider) async fn claude_messages_unscoped(
     State(state): State<Arc<AppState>>,
     headers: HeaderMap,
-    Json(mut body): Json<claude_create_message_request::RequestBody>,
+    body: Bytes,
 ) -> Result<Response, HttpError> {
     let auth = authorize_provider_access(&headers, &state)?;
-    let model = serialize_json_scalar(&body.model, "claude model")?;
-    let (provider_name, stripped_model) = split_provider_prefixed_plain_model(model.as_str())?;
-    body.model = deserialize_json_scalar(stripped_model.as_str(), "claude model")?;
-    let (channel, provider) = resolve_provider(&state, provider_name.as_str())?;
-    let mut request = claude_create_message_request::ClaudeCreateMessageRequest {
-        body,
-        ..Default::default()
+    let mut body = parse_json_body::<Value>(&body, "invalid claude messages request body")?;
+    let model = required_string_field(
+        &body,
+        "/model",
+        "missing `model` in claude messages request body",
+        "`model` in claude messages request body must be a string",
+    )?;
+    let (provider_name, stripped_model) = split_provider_prefixed_plain_model(model)?;
+    set_string_field(
+        &mut body,
+        "/model",
+        stripped_model,
+        "missing `model` in claude messages request body",
+    )?;
+    let operation = if stream_enabled(&body) {
+        OperationFamily::StreamGenerateContent
+    } else {
+        OperationFamily::GenerateContent
     };
     let (version, beta) = anthropic_headers_from_request(&headers);
-    request.headers.anthropic_version = version;
-    if beta.is_some() {
-        request.headers.anthropic_beta = beta;
-    }
-    let envelope = if request.body.stream.unwrap_or(false) {
-        TransformRequest::StreamGenerateContentClaude(request)
-    } else {
-        TransformRequest::GenerateContentClaude(request)
-    };
-    execute_transform_request(state, channel, provider, auth, envelope)
+    let payload_body = build_claude_payload(
+        body,
+        json!({
+            "anthropic_version": version,
+            "anthropic_beta": beta,
+        }),
+        "invalid claude messages request body",
+    )?;
+    let (channel, provider) = resolve_provider(&state, provider_name.as_str())?;
+    let payload =
+        TransformRequestPayload::from_bytes(operation, ProtocolKind::Claude, payload_body);
+    execute_transform_request_payload(state, channel, provider, auth, payload)
         .await
         .map_err(HttpError::from)
 }
@@ -76,56 +139,66 @@ pub(in crate::routes::provider) async fn claude_count_tokens(
     State(state): State<Arc<AppState>>,
     Path(provider_name): Path<String>,
     headers: HeaderMap,
-    Json(body): Json<claude_count_tokens_request::RequestBody>,
+    body: Bytes,
 ) -> Result<Response, HttpError> {
     let auth = authorize_provider_access(&headers, &state)?;
     let (channel, provider) = resolve_provider(&state, provider_name.as_str())?;
-    let mut request = claude_count_tokens_request::ClaudeCountTokensRequest {
-        body,
-        ..Default::default()
-    };
+    let body = parse_json_body::<Value>(&body, "invalid claude count_tokens request body")?;
     let (version, beta) = anthropic_headers_from_request(&headers);
-    request.headers.anthropic_version = version;
-    if beta.is_some() {
-        request.headers.anthropic_beta = beta;
-    }
-    execute_transform_request(
-        state,
-        channel,
-        provider,
-        auth,
-        TransformRequest::CountTokenClaude(request),
-    )
-    .await
-    .map_err(HttpError::from)
+    let payload_body = build_claude_payload(
+        body,
+        json!({
+            "anthropic_version": version,
+            "anthropic_beta": beta,
+        }),
+        "invalid claude count_tokens request body",
+    )?;
+    let payload = TransformRequestPayload::from_bytes(
+        OperationFamily::CountToken,
+        ProtocolKind::Claude,
+        payload_body,
+    );
+    execute_transform_request_payload(state, channel, provider, auth, payload)
+        .await
+        .map_err(HttpError::from)
 }
 
 pub(in crate::routes::provider) async fn claude_count_tokens_unscoped(
     State(state): State<Arc<AppState>>,
     headers: HeaderMap,
-    Json(mut body): Json<claude_count_tokens_request::RequestBody>,
+    body: Bytes,
 ) -> Result<Response, HttpError> {
     let auth = authorize_provider_access(&headers, &state)?;
-    let model = serialize_json_scalar(&body.model, "claude model")?;
-    let (provider_name, stripped_model) = split_provider_prefixed_plain_model(model.as_str())?;
-    body.model = deserialize_json_scalar(stripped_model.as_str(), "claude model")?;
-    let (channel, provider) = resolve_provider(&state, provider_name.as_str())?;
-    let mut request = claude_count_tokens_request::ClaudeCountTokensRequest {
-        body,
-        ..Default::default()
-    };
+    let mut body = parse_json_body::<Value>(&body, "invalid claude count_tokens request body")?;
+    let model = required_string_field(
+        &body,
+        "/model",
+        "missing `model` in claude count_tokens request body",
+        "`model` in claude count_tokens request body must be a string",
+    )?;
+    let (provider_name, stripped_model) = split_provider_prefixed_plain_model(model)?;
+    set_string_field(
+        &mut body,
+        "/model",
+        stripped_model,
+        "missing `model` in claude count_tokens request body",
+    )?;
     let (version, beta) = anthropic_headers_from_request(&headers);
-    request.headers.anthropic_version = version;
-    if beta.is_some() {
-        request.headers.anthropic_beta = beta;
-    }
-    execute_transform_request(
-        state,
-        channel,
-        provider,
-        auth,
-        TransformRequest::CountTokenClaude(request),
-    )
-    .await
-    .map_err(HttpError::from)
+    let payload_body = build_claude_payload(
+        body,
+        json!({
+            "anthropic_version": version,
+            "anthropic_beta": beta,
+        }),
+        "invalid claude count_tokens request body",
+    )?;
+    let (channel, provider) = resolve_provider(&state, provider_name.as_str())?;
+    let payload = TransformRequestPayload::from_bytes(
+        OperationFamily::CountToken,
+        ProtocolKind::Claude,
+        payload_body,
+    );
+    execute_transform_request_payload(state, channel, provider, auth, payload)
+        .await
+        .map_err(HttpError::from)
 }

--- a/crates/gproxy-core/src/routes/provider/handlers/gemini.rs
+++ b/crates/gproxy-core/src/routes/provider/handlers/gemini.rs
@@ -4,24 +4,47 @@ use axum::body::Bytes;
 use axum::extract::{Path, RawQuery, State};
 use axum::http::{HeaderMap, StatusCode};
 use axum::response::Response;
-use gproxy_middleware::TransformRequest;
-use gproxy_protocol::gemini::count_tokens::request as gemini_count_tokens_request;
-use gproxy_protocol::gemini::embeddings::request as gemini_embeddings_request;
-use gproxy_protocol::gemini::generate_content::request as gemini_generate_content_request;
+use gproxy_middleware::{OperationFamily, ProtocolKind, TransformRequest, TransformRequestPayload};
 use gproxy_protocol::gemini::model_get::request as gemini_model_get_request;
 use gproxy_protocol::gemini::model_list::request as gemini_model_list_request;
-use gproxy_protocol::gemini::stream_generate_content::request as gemini_stream_generate_content_request;
 use gproxy_provider::parse_query_value;
-use serde_json::json;
+use serde_json::{Value, json};
 
 use crate::AppState;
 
 use super::super::{
     HttpError, authorize_provider_access, bad_request, collect_unscoped_model_ids,
-    execute_transform_request, internal_error, normalize_gemini_model_path, parse_json_body,
-    parse_optional_query_value, resolve_provider, response_from_status_headers_and_bytes,
-    split_provider_prefixed_gemini_target, split_provider_prefixed_model_path,
+    execute_transform_request, execute_transform_request_payload, internal_error,
+    normalize_gemini_model_path, parse_optional_query_value, resolve_provider,
+    response_from_status_headers_and_bytes, split_provider_prefixed_gemini_target,
+    split_provider_prefixed_model_path,
 };
+
+fn encode_json_value(value: &Value, context: &str) -> Result<Bytes, HttpError> {
+    serde_json::to_vec(value)
+        .map(Bytes::from)
+        .map_err(|err| bad_request(format!("{context}: {err}")))
+}
+
+fn build_gemini_payload(
+    model: String,
+    body: Value,
+    alt: Option<&str>,
+    context: &str,
+) -> Result<Bytes, HttpError> {
+    let mut payload = json!({
+        "path": {
+            "model": model,
+        },
+        "body": body,
+    });
+    if let Some(alt) = alt
+        && let Some(map) = payload.as_object_mut()
+    {
+        map.insert("query".to_string(), json!({ "alt": alt }));
+    }
+    encode_json_value(&payload, context)
+}
 
 pub(in crate::routes::provider) async fn v1beta_model_list(
     State(state): State<Arc<AppState>>,
@@ -168,93 +191,103 @@ pub(in crate::routes::provider) async fn handle_gemini_post_target(
 
     if let Some(model) = target.strip_suffix(":generateContent") {
         let normalized_model = normalize_gemini_model_path(model)?;
-        let request_body = parse_json_body::<gemini_generate_content_request::RequestBody>(
-            &body,
+        let body = serde_json::from_slice::<Value>(&body).map_err(|err| {
+            bad_request(format!(
+                "invalid gemini generateContent request body: {err}"
+            ))
+        })?;
+        let payload_body = build_gemini_payload(
+            normalized_model,
+            body,
+            None,
             "invalid gemini generateContent request body",
         )?;
-        let mut request = gemini_generate_content_request::GeminiGenerateContentRequest::default();
-        request.path.model = normalized_model;
-        request.body = request_body;
-        return execute_transform_request(
-            state,
-            channel,
-            provider,
-            auth,
-            TransformRequest::GenerateContentGemini(request),
-        )
-        .await
-        .map_err(HttpError::from);
+        let payload = TransformRequestPayload::from_bytes(
+            OperationFamily::GenerateContent,
+            ProtocolKind::Gemini,
+            payload_body,
+        );
+        return execute_transform_request_payload(state, channel, provider, auth, payload)
+            .await
+            .map_err(HttpError::from);
     }
 
     if let Some(model) = target.strip_suffix(":streamGenerateContent") {
         let normalized_model = normalize_gemini_model_path(model)?;
-        let request_body = parse_json_body::<gemini_stream_generate_content_request::RequestBody>(
-            &body,
-            "invalid gemini streamGenerateContent request body",
-        )?;
-        let mut request =
-            gemini_stream_generate_content_request::GeminiStreamGenerateContentRequest::default();
-        request.path.model = normalized_model;
-        request.body = request_body;
+        let body = serde_json::from_slice::<Value>(&body).map_err(|err| {
+            bad_request(format!(
+                "invalid gemini streamGenerateContent request body: {err}"
+            ))
+        })?;
 
         let alt = parse_query_value(query.as_deref(), "alt");
-        let envelope = match alt.as_deref() {
-            Some("sse") | Some("SSE") => {
-                request.query.alt =
-                    Some(gemini_stream_generate_content_request::AltQueryParameter::Sse);
-                TransformRequest::StreamGenerateContentGeminiSse(request)
-            }
+        let (protocol, payload_alt) = match alt.as_deref() {
+            Some("sse") | Some("SSE") => (ProtocolKind::Gemini, Some("sse")),
             Some(other) => {
                 return Err(bad_request(format!(
                     "unsupported gemini stream `alt` query parameter: {other}"
                 )));
             }
-            None => TransformRequest::StreamGenerateContentGeminiNdjson(request),
+            None => (ProtocolKind::GeminiNDJson, None),
         };
 
-        return execute_transform_request(state, channel, provider, auth, envelope)
+        let payload_body = build_gemini_payload(
+            normalized_model,
+            body,
+            payload_alt,
+            "invalid gemini streamGenerateContent request body",
+        )?;
+        let payload = TransformRequestPayload::from_bytes(
+            OperationFamily::StreamGenerateContent,
+            protocol,
+            payload_body,
+        );
+
+        return execute_transform_request_payload(state, channel, provider, auth, payload)
             .await
             .map_err(HttpError::from);
     }
 
     if let Some(model) = target.strip_suffix(":countTokens") {
         let normalized_model = normalize_gemini_model_path(model)?;
-        let request_body = parse_json_body::<gemini_count_tokens_request::RequestBody>(
-            &body,
+        let body = serde_json::from_slice::<Value>(&body).map_err(|err| {
+            bad_request(format!("invalid gemini countTokens request body: {err}"))
+        })?;
+        let payload_body = build_gemini_payload(
+            normalized_model,
+            body,
+            None,
             "invalid gemini countTokens request body",
         )?;
-        let mut request = gemini_count_tokens_request::GeminiCountTokensRequest::default();
-        request.path.model = normalized_model;
-        request.body = request_body;
-        return execute_transform_request(
-            state,
-            channel,
-            provider,
-            auth,
-            TransformRequest::CountTokenGemini(request),
-        )
-        .await
-        .map_err(HttpError::from);
+        let payload = TransformRequestPayload::from_bytes(
+            OperationFamily::CountToken,
+            ProtocolKind::Gemini,
+            payload_body,
+        );
+        return execute_transform_request_payload(state, channel, provider, auth, payload)
+            .await
+            .map_err(HttpError::from);
     }
 
     if let Some(model) = target.strip_suffix(":embedContent") {
         let normalized_model = normalize_gemini_model_path(model)?;
-        let request_body = parse_json_body::<gemini_embeddings_request::RequestBody>(
-            &body,
+        let body = serde_json::from_slice::<Value>(&body).map_err(|err| {
+            bad_request(format!("invalid gemini embedContent request body: {err}"))
+        })?;
+        let payload_body = build_gemini_payload(
+            normalized_model,
+            body,
+            None,
             "invalid gemini embedContent request body",
         )?;
-        let mut request = gemini_embeddings_request::GeminiEmbedContentRequest::default();
-        request.path.model = normalized_model;
-        request.body = request_body;
-        return execute_transform_request(
-            state,
-            channel,
-            provider,
-            auth,
-            TransformRequest::EmbeddingGemini(request),
-        )
-        .await
-        .map_err(HttpError::from);
+        let payload = TransformRequestPayload::from_bytes(
+            OperationFamily::Embedding,
+            ProtocolKind::Gemini,
+            payload_body,
+        );
+        return execute_transform_request_payload(state, channel, provider, auth, payload)
+            .await
+            .map_err(HttpError::from);
     }
 
     Err(HttpError::new(

--- a/crates/gproxy-core/src/routes/provider/handlers/openai.rs
+++ b/crates/gproxy-core/src/routes/provider/handlers/openai.rs
@@ -1,18 +1,16 @@
 use std::sync::Arc;
 
-use axum::Json;
+use axum::body::Bytes;
 use axum::extract::{Path, RawQuery, State};
 use axum::http::{HeaderMap, StatusCode};
 use axum::response::Response;
-use gproxy_middleware::TransformRequest;
+use gproxy_middleware::{OperationFamily, ProtocolKind, TransformRequest, TransformRequestPayload};
 use gproxy_protocol::claude::model_get::request as claude_model_get_request;
 use gproxy_protocol::claude::model_list::request as claude_model_list_request;
 use gproxy_protocol::gemini::model_get::request as gemini_model_get_request;
 use gproxy_protocol::gemini::model_list::request as gemini_model_list_request;
 use gproxy_protocol::openai::compact_response::request as openai_compact_request;
 use gproxy_protocol::openai::count_tokens::request as openai_count_tokens_request;
-use gproxy_protocol::openai::create_chat_completions::request as openai_chat_completions_request;
-use gproxy_protocol::openai::create_response::request as openai_create_response_request;
 use gproxy_protocol::openai::embeddings::request as openai_embeddings_request;
 use gproxy_protocol::openai::model_get::request as openai_model_get_request;
 use gproxy_protocol::openai::model_list::request as openai_model_list_request;
@@ -27,13 +25,12 @@ use super::super::{
     HttpError, ModelProtocolPreference, UpstreamResponseMeta, anthropic_headers_from_request,
     apply_credential_update_and_persist, authorize_provider_access, bad_request,
     capture_tracked_http_events, collect_headers, collect_unscoped_model_ids,
-    deserialize_json_scalar, enqueue_internal_tracked_http_events,
-    enqueue_upstream_request_event_from_meta, execute_transform_candidates,
-    execute_transform_request, internal_error, model_protocol_preference,
-    normalize_gemini_model_path, now_unix_ms, oauth_callback_response_to_axum,
-    oauth_response_to_axum, parse_optional_query_value, persist_provider_and_credential,
-    resolve_credential_id, resolve_provider, resolve_provider_id,
-    response_from_status_headers_and_bytes, serialize_json_scalar,
+    enqueue_internal_tracked_http_events, enqueue_upstream_request_event_from_meta,
+    execute_transform_candidates, execute_transform_request_payload, internal_error,
+    model_protocol_preference, normalize_gemini_model_path, now_unix_ms,
+    oauth_callback_response_to_axum, oauth_response_to_axum, parse_json_body,
+    parse_optional_query_value, persist_provider_and_credential, resolve_credential_id,
+    resolve_provider, resolve_provider_id, response_from_status_headers_and_bytes,
     split_provider_prefixed_plain_model, upstream_error_request_meta, upstream_error_status,
     websocket_upgrade_required_response,
 };
@@ -364,24 +361,64 @@ pub(in crate::routes::provider) async fn handle_openai_realtime_upgrade(
     ))
 }
 
+fn required_string_field<'a>(
+    value: &'a serde_json::Value,
+    pointer: &str,
+    missing_message: &str,
+    invalid_message: &str,
+) -> Result<&'a str, HttpError> {
+    let Some(raw) = value.pointer(pointer) else {
+        return Err(bad_request(missing_message));
+    };
+    raw.as_str().ok_or_else(|| bad_request(invalid_message))
+}
+
+fn set_string_field(
+    value: &mut serde_json::Value,
+    pointer: &str,
+    new_value: String,
+    missing_message: &str,
+) -> Result<(), HttpError> {
+    let Some(slot) = value.pointer_mut(pointer) else {
+        return Err(bad_request(missing_message));
+    };
+    *slot = serde_json::Value::String(new_value);
+    Ok(())
+}
+
+fn stream_enabled(value: &serde_json::Value) -> bool {
+    value
+        .pointer("/stream")
+        .and_then(serde_json::Value::as_bool)
+        .unwrap_or(false)
+}
+
+fn encode_json_value(value: &serde_json::Value, context: &str) -> Result<Bytes, HttpError> {
+    serde_json::to_vec(value)
+        .map(Bytes::from)
+        .map_err(|err| bad_request(format!("{context}: {err}")))
+}
+
 pub(in crate::routes::provider) async fn openai_chat_completions(
     State(state): State<Arc<AppState>>,
     Path(provider_name): Path<String>,
     headers: HeaderMap,
-    Json(body): Json<openai_chat_completions_request::RequestBody>,
+    body: Bytes,
 ) -> Result<Response, HttpError> {
     let auth = authorize_provider_access(&headers, &state)?;
     let (channel, provider) = resolve_provider(&state, provider_name.as_str())?;
-    let request = openai_chat_completions_request::OpenAiChatCompletionsRequest {
-        body,
-        ..Default::default()
-    };
-    let envelope = if request.body.stream.unwrap_or(false) {
-        TransformRequest::StreamGenerateContentOpenAiChatCompletions(request)
+    let value = parse_json_body::<serde_json::Value>(
+        &body,
+        "invalid openai chat completions request body",
+    )?;
+    let operation = if stream_enabled(&value) {
+        OperationFamily::StreamGenerateContent
     } else {
-        TransformRequest::GenerateContentOpenAiChatCompletions(request)
+        OperationFamily::GenerateContent
     };
-    execute_transform_request(state, channel, provider, auth, envelope)
+    let payload =
+        TransformRequestPayload::from_bytes(operation, ProtocolKind::OpenAiChatCompletion, body);
+    execute_transform_request_payload(state, channel, provider, auth, payload)
         .await
         .map_err(HttpError::from)
 }
@@ -389,22 +426,36 @@ pub(in crate::routes::provider) async fn openai_chat_completions(
 pub(in crate::routes::provider) async fn openai_chat_completions_unscoped(
     State(state): State<Arc<AppState>>,
     headers: HeaderMap,
-    Json(mut body): Json<openai_chat_completions_request::RequestBody>,
+    body: Bytes,
 ) -> Result<Response, HttpError> {
     let auth = authorize_provider_access(&headers, &state)?;
-    let (provider_name, stripped_model) = split_provider_prefixed_plain_model(body.model.as_str())?;
-    body.model = stripped_model;
-    let (channel, provider) = resolve_provider(&state, provider_name.as_str())?;
-    let request = openai_chat_completions_request::OpenAiChatCompletionsRequest {
-        body,
-        ..Default::default()
-    };
-    let envelope = if request.body.stream.unwrap_or(false) {
-        TransformRequest::StreamGenerateContentOpenAiChatCompletions(request)
+    let mut body = parse_json_body::<serde_json::Value>(
+        &body,
+        "invalid openai chat completions request body",
+    )?;
+    let model = required_string_field(
+        &body,
+        "/model",
+        "missing `model` in OpenAI chat completions request body",
+        "`model` in OpenAI chat completions request body must be a string",
+    )?;
+    let (provider_name, stripped_model) = split_provider_prefixed_plain_model(model)?;
+    set_string_field(
+        &mut body,
+        "/model",
+        stripped_model,
+        "missing `model` in OpenAI chat completions request body",
+    )?;
+    let operation = if stream_enabled(&body) {
+        OperationFamily::StreamGenerateContent
     } else {
-        TransformRequest::GenerateContentOpenAiChatCompletions(request)
+        OperationFamily::GenerateContent
     };
-    execute_transform_request(state, channel, provider, auth, envelope)
+    let body = encode_json_value(&body, "invalid openai chat completions request body")?;
+    let (channel, provider) = resolve_provider(&state, provider_name.as_str())?;
+    let payload =
+        TransformRequestPayload::from_bytes(operation, ProtocolKind::OpenAiChatCompletion, body);
+    execute_transform_request_payload(state, channel, provider, auth, payload)
         .await
         .map_err(HttpError::from)
 }
@@ -413,20 +464,19 @@ pub(in crate::routes::provider) async fn openai_responses(
     State(state): State<Arc<AppState>>,
     Path(provider_name): Path<String>,
     headers: HeaderMap,
-    Json(body): Json<openai_create_response_request::RequestBody>,
+    body: Bytes,
 ) -> Result<Response, HttpError> {
     let auth = authorize_provider_access(&headers, &state)?;
     let (channel, provider) = resolve_provider(&state, provider_name.as_str())?;
-    let request = openai_create_response_request::OpenAiCreateResponseRequest {
-        body,
-        ..Default::default()
-    };
-    let envelope = if request.body.stream.unwrap_or(false) {
-        TransformRequest::StreamGenerateContentOpenAiResponse(request)
+    let value =
+        parse_json_body::<serde_json::Value>(&body, "invalid openai responses request body")?;
+    let operation = if stream_enabled(&value) {
+        OperationFamily::StreamGenerateContent
     } else {
-        TransformRequest::GenerateContentOpenAiResponse(request)
+        OperationFamily::GenerateContent
     };
-    execute_transform_request(state, channel, provider, auth, envelope)
+    let payload = TransformRequestPayload::from_bytes(operation, ProtocolKind::OpenAi, body);
+    execute_transform_request_payload(state, channel, provider, auth, payload)
         .await
         .map_err(HttpError::from)
 }
@@ -434,26 +484,33 @@ pub(in crate::routes::provider) async fn openai_responses(
 pub(in crate::routes::provider) async fn openai_responses_unscoped(
     State(state): State<Arc<AppState>>,
     headers: HeaderMap,
-    Json(mut body): Json<openai_create_response_request::RequestBody>,
+    body: Bytes,
 ) -> Result<Response, HttpError> {
     let auth = authorize_provider_access(&headers, &state)?;
-    let model = body
-        .model
-        .clone()
-        .ok_or_else(|| bad_request("missing `model` in OpenAI responses request body"))?;
-    let (provider_name, stripped_model) = split_provider_prefixed_plain_model(model.as_str())?;
-    body.model = Some(stripped_model);
-    let (channel, provider) = resolve_provider(&state, provider_name.as_str())?;
-    let request = openai_create_response_request::OpenAiCreateResponseRequest {
-        body,
-        ..Default::default()
-    };
-    let envelope = if request.body.stream.unwrap_or(false) {
-        TransformRequest::StreamGenerateContentOpenAiResponse(request)
+    let mut body =
+        parse_json_body::<serde_json::Value>(&body, "invalid openai responses request body")?;
+    let model = required_string_field(
+        &body,
+        "/model",
+        "missing `model` in OpenAI responses request body",
+        "`model` in OpenAI responses request body must be a string",
+    )?;
+    let (provider_name, stripped_model) = split_provider_prefixed_plain_model(model)?;
+    set_string_field(
+        &mut body,
+        "/model",
+        stripped_model,
+        "missing `model` in OpenAI responses request body",
+    )?;
+    let operation = if stream_enabled(&body) {
+        OperationFamily::StreamGenerateContent
     } else {
-        TransformRequest::GenerateContentOpenAiResponse(request)
+        OperationFamily::GenerateContent
     };
-    execute_transform_request(state, channel, provider, auth, envelope)
+    let body = encode_json_value(&body, "invalid openai responses request body")?;
+    let (channel, provider) = resolve_provider(&state, provider_name.as_str())?;
+    let payload = TransformRequestPayload::from_bytes(operation, ProtocolKind::OpenAi, body);
+    execute_transform_request_payload(state, channel, provider, auth, payload)
         .await
         .map_err(HttpError::from)
 }
@@ -462,146 +519,153 @@ pub(in crate::routes::provider) async fn openai_input_tokens(
     State(state): State<Arc<AppState>>,
     Path(provider_name): Path<String>,
     headers: HeaderMap,
-    Json(body): Json<openai_count_tokens_request::RequestBody>,
+    body: Bytes,
 ) -> Result<Response, HttpError> {
+    let _ = parse_json_body::<openai_count_tokens_request::RequestBody>(
+        &body,
+        "invalid openai input_tokens request body",
+    )?;
     let auth = authorize_provider_access(&headers, &state)?;
     let (channel, provider) = resolve_provider(&state, provider_name.as_str())?;
-    let request = openai_count_tokens_request::OpenAiCountTokensRequest {
+    let payload = TransformRequestPayload::from_bytes(
+        OperationFamily::CountToken,
+        ProtocolKind::OpenAi,
         body,
-        ..Default::default()
-    };
-    execute_transform_request(
-        state,
-        channel,
-        provider,
-        auth,
-        TransformRequest::CountTokenOpenAi(request),
-    )
-    .await
-    .map_err(HttpError::from)
+    );
+    execute_transform_request_payload(state, channel, provider, auth, payload)
+        .await
+        .map_err(HttpError::from)
 }
 
 pub(in crate::routes::provider) async fn openai_input_tokens_unscoped(
     State(state): State<Arc<AppState>>,
     headers: HeaderMap,
-    Json(mut body): Json<openai_count_tokens_request::RequestBody>,
+    body: Bytes,
 ) -> Result<Response, HttpError> {
     let auth = authorize_provider_access(&headers, &state)?;
-    let model = body
-        .model
-        .clone()
-        .ok_or_else(|| bad_request("missing `model` in OpenAI input_tokens request body"))?;
-    let (provider_name, stripped_model) = split_provider_prefixed_plain_model(model.as_str())?;
-    body.model = Some(stripped_model);
+    let mut body =
+        parse_json_body::<serde_json::Value>(&body, "invalid openai input_tokens request body")?;
+    let model = required_string_field(
+        &body,
+        "/model",
+        "missing `model` in OpenAI input_tokens request body",
+        "`model` in OpenAI input_tokens request body must be a string",
+    )?;
+    let (provider_name, stripped_model) = split_provider_prefixed_plain_model(model)?;
+    set_string_field(
+        &mut body,
+        "/model",
+        stripped_model,
+        "missing `model` in OpenAI input_tokens request body",
+    )?;
+    let body = encode_json_value(&body, "invalid openai input_tokens request body")?;
     let (channel, provider) = resolve_provider(&state, provider_name.as_str())?;
-    let request = openai_count_tokens_request::OpenAiCountTokensRequest {
+    let payload = TransformRequestPayload::from_bytes(
+        OperationFamily::CountToken,
+        ProtocolKind::OpenAi,
         body,
-        ..Default::default()
-    };
-    execute_transform_request(
-        state,
-        channel,
-        provider,
-        auth,
-        TransformRequest::CountTokenOpenAi(request),
-    )
-    .await
-    .map_err(HttpError::from)
+    );
+    execute_transform_request_payload(state, channel, provider, auth, payload)
+        .await
+        .map_err(HttpError::from)
 }
 
 pub(in crate::routes::provider) async fn openai_embeddings(
     State(state): State<Arc<AppState>>,
     Path(provider_name): Path<String>,
     headers: HeaderMap,
-    Json(body): Json<openai_embeddings_request::RequestBody>,
+    body: Bytes,
 ) -> Result<Response, HttpError> {
+    let _ = parse_json_body::<openai_embeddings_request::RequestBody>(
+        &body,
+        "invalid openai embeddings request body",
+    )?;
     let auth = authorize_provider_access(&headers, &state)?;
     let (channel, provider) = resolve_provider(&state, provider_name.as_str())?;
-    let request = openai_embeddings_request::OpenAiEmbeddingsRequest {
-        body,
-        ..Default::default()
-    };
-    execute_transform_request(
-        state,
-        channel,
-        provider,
-        auth,
-        TransformRequest::EmbeddingOpenAi(request),
-    )
-    .await
-    .map_err(HttpError::from)
+    let payload =
+        TransformRequestPayload::from_bytes(OperationFamily::Embedding, ProtocolKind::OpenAi, body);
+    execute_transform_request_payload(state, channel, provider, auth, payload)
+        .await
+        .map_err(HttpError::from)
 }
 
 pub(in crate::routes::provider) async fn openai_embeddings_unscoped(
     State(state): State<Arc<AppState>>,
     headers: HeaderMap,
-    Json(mut body): Json<openai_embeddings_request::RequestBody>,
+    body: Bytes,
 ) -> Result<Response, HttpError> {
     let auth = authorize_provider_access(&headers, &state)?;
-    let model = serialize_json_scalar(&body.model, "openai embeddings model")?;
-    let (provider_name, stripped_model) = split_provider_prefixed_plain_model(model.as_str())?;
-    body.model = deserialize_json_scalar(stripped_model.as_str(), "openai embeddings model")?;
+    let mut body =
+        parse_json_body::<serde_json::Value>(&body, "invalid openai embeddings request body")?;
+    let model = required_string_field(
+        &body,
+        "/model",
+        "missing `model` in OpenAI embeddings request body",
+        "`model` in OpenAI embeddings request body must be a string",
+    )?;
+    let (provider_name, stripped_model) = split_provider_prefixed_plain_model(model)?;
+    set_string_field(
+        &mut body,
+        "/model",
+        stripped_model,
+        "missing `model` in OpenAI embeddings request body",
+    )?;
+    let body = encode_json_value(&body, "invalid openai embeddings request body")?;
     let (channel, provider) = resolve_provider(&state, provider_name.as_str())?;
-    let request = openai_embeddings_request::OpenAiEmbeddingsRequest {
-        body,
-        ..Default::default()
-    };
-    execute_transform_request(
-        state,
-        channel,
-        provider,
-        auth,
-        TransformRequest::EmbeddingOpenAi(request),
-    )
-    .await
-    .map_err(HttpError::from)
+    let payload =
+        TransformRequestPayload::from_bytes(OperationFamily::Embedding, ProtocolKind::OpenAi, body);
+    execute_transform_request_payload(state, channel, provider, auth, payload)
+        .await
+        .map_err(HttpError::from)
 }
 
 pub(in crate::routes::provider) async fn openai_compact(
     State(state): State<Arc<AppState>>,
     Path(provider_name): Path<String>,
     headers: HeaderMap,
-    Json(body): Json<openai_compact_request::RequestBody>,
+    body: Bytes,
 ) -> Result<Response, HttpError> {
+    let _ = parse_json_body::<openai_compact_request::RequestBody>(
+        &body,
+        "invalid openai compact request body",
+    )?;
     let auth = authorize_provider_access(&headers, &state)?;
     let (channel, provider) = resolve_provider(&state, provider_name.as_str())?;
-    let request = openai_compact_request::OpenAiCompactRequest {
-        body,
-        ..Default::default()
-    };
-    execute_transform_request(
-        state,
-        channel,
-        provider,
-        auth,
-        TransformRequest::CompactOpenAi(request),
-    )
-    .await
-    .map_err(HttpError::from)
+    let payload =
+        TransformRequestPayload::from_bytes(OperationFamily::Compact, ProtocolKind::OpenAi, body);
+    execute_transform_request_payload(state, channel, provider, auth, payload)
+        .await
+        .map_err(HttpError::from)
 }
 
 pub(in crate::routes::provider) async fn openai_compact_unscoped(
     State(state): State<Arc<AppState>>,
     headers: HeaderMap,
-    Json(mut body): Json<openai_compact_request::RequestBody>,
+    body: Bytes,
 ) -> Result<Response, HttpError> {
     let auth = authorize_provider_access(&headers, &state)?;
-    let (provider_name, stripped_model) = split_provider_prefixed_plain_model(body.model.as_str())?;
-    body.model = stripped_model;
+    let mut body =
+        parse_json_body::<serde_json::Value>(&body, "invalid openai compact request body")?;
+    let model = required_string_field(
+        &body,
+        "/model",
+        "missing `model` in OpenAI compact request body",
+        "`model` in OpenAI compact request body must be a string",
+    )?;
+    let (provider_name, stripped_model) = split_provider_prefixed_plain_model(model)?;
+    set_string_field(
+        &mut body,
+        "/model",
+        stripped_model,
+        "missing `model` in OpenAI compact request body",
+    )?;
+    let body = encode_json_value(&body, "invalid openai compact request body")?;
     let (channel, provider) = resolve_provider(&state, provider_name.as_str())?;
-    let request = openai_compact_request::OpenAiCompactRequest {
-        body,
-        ..Default::default()
-    };
-    execute_transform_request(
-        state,
-        channel,
-        provider,
-        auth,
-        TransformRequest::CompactOpenAi(request),
-    )
-    .await
-    .map_err(HttpError::from)
+    let payload =
+        TransformRequestPayload::from_bytes(OperationFamily::Compact, ProtocolKind::OpenAi, body);
+    execute_transform_request_payload(state, channel, provider, auth, payload)
+        .await
+        .map_err(HttpError::from)
 }
 
 pub(in crate::routes::provider) async fn v1_model_list(

--- a/crates/gproxy-core/src/routes/provider/model_prefix.rs
+++ b/crates/gproxy-core/src/routes/provider/model_prefix.rs
@@ -11,26 +11,6 @@ pub(super) fn parse_json_body<T: DeserializeOwned>(
     serde_json::from_slice(body).map_err(|err| bad_request(format!("{context}: {err}")))
 }
 
-pub(super) fn serialize_json_scalar<T: serde::Serialize>(
-    value: &T,
-    context: &str,
-) -> Result<String, HttpError> {
-    let value = serde_json::to_value(value)
-        .map_err(|err| bad_request(format!("invalid {context}: {err}")))?;
-    value
-        .as_str()
-        .map(ToOwned::to_owned)
-        .ok_or_else(|| bad_request(format!("{context} must be a string")))
-}
-
-pub(super) fn deserialize_json_scalar<T: DeserializeOwned>(
-    value: &str,
-    context: &str,
-) -> Result<T, HttpError> {
-    serde_json::from_value(serde_json::Value::String(value.to_string()))
-        .map_err(|err| bad_request(format!("invalid {context}: {err}")))
-}
-
 pub(super) fn split_provider_prefixed_plain_model(
     raw: &str,
 ) -> Result<(String, String), HttpError> {

--- a/crates/gproxy-core/src/routes/provider/recording.rs
+++ b/crates/gproxy-core/src/routes/provider/recording.rs
@@ -4,8 +4,8 @@ use super::{
     OpenAiEmbeddingUsage, OperationFamily, ProtocolKind, ProviderDefinition, RequestAuthContext,
     ResponseInput, ResponseUsage, RouteImplementation, RouteKey, StorageWriteEvent, SystemTime,
     TokenizerResolutionContext, TrackedHttpEvent, TransformRequest, UNIX_EPOCH, UpstreamError,
-    UpstreamRequestMeta, UpstreamRequestWrite, UpstreamStreamRecordContext, UsageSnapshot,
-    UsageWrite, claude_count_tokens_request, claude_count_tokens_response,
+    UpstreamRequestMeta, UpstreamRequestWrite, UpstreamStreamRecordContext, UsageRequestContext,
+    UsageSnapshot, UsageWrite, claude_count_tokens_request, claude_count_tokens_response,
     claude_create_message_response, execute_local_count_token_request, gemini_count_tokens_request,
     gemini_count_tokens_response, gemini_generate_content_response,
     openai_chat_completions_response, openai_compact_response_response,
@@ -434,18 +434,19 @@ pub(super) fn strip_model_fields(value: &mut serde_json::Value) {
     }
 }
 
-pub(super) async fn estimate_embedding_input_tokens_from_request(
+pub(super) async fn estimate_embedding_input_tokens_from_usage_request(
     state: &AppState,
-    request: &TransformRequest,
+    request: &UsageRequestContext,
 ) -> Option<i64> {
     if request.operation() != OperationFamily::Embedding {
         return None;
     }
-    let model = extract_model_from_request(request)?.trim().to_string();
+    let model = request.model.as_ref()?.trim().to_string();
     if model.is_empty() {
         return None;
     }
-    let mut value = serde_json::to_value(request).ok()?;
+    let body = request.body_for_estimate.as_ref()?;
+    let mut value = serde_json::from_slice::<serde_json::Value>(body).ok()?;
     strip_model_fields(&mut value);
     let text = serde_json::to_string(&value).ok()?;
     let count = state
@@ -630,7 +631,7 @@ pub(super) async fn enqueue_stream_usage_event_with_estimate(
         return;
     }
 
-    let request_model = normalize_usage_model(extract_model_from_request(&context.request));
+    let request_model = normalize_usage_model(context.request.model.clone());
     let model = request_model
         .as_deref()
         .map(str::trim)
@@ -673,7 +674,17 @@ pub(super) async fn enqueue_stream_usage_event_with_estimate(
         && cache_creation_input_tokens_5min.is_none()
         && cache_creation_input_tokens_1h.is_none()
     {
-        let request_text = serde_json::to_string(&context.request).unwrap_or_default();
+        let request_text = context
+            .request
+            .body_for_estimate
+            .as_deref()
+            .map(|body| {
+                serde_json::from_slice::<serde_json::Value>(body)
+                    .ok()
+                    .and_then(|value| serde_json::to_string(&value).ok())
+                    .unwrap_or_else(|| String::from_utf8_lossy(body).to_string())
+            })
+            .unwrap_or_default();
         let response_text = String::from_utf8_lossy(stream_response_body).to_string();
 
         input_tokens =
@@ -718,6 +729,90 @@ pub(super) fn serialize_openai_embedding_model(model: &OpenAiEmbeddingModel) -> 
     serde_json::to_value(model)
         .ok()
         .and_then(|value| value.as_str().map(ToOwned::to_owned))
+}
+
+fn json_pointer_string(value: &serde_json::Value, pointer: &str) -> Option<String> {
+    value
+        .pointer(pointer)
+        .and_then(serde_json::Value::as_str)
+        .map(ToOwned::to_owned)
+}
+
+pub(super) fn extract_model_from_payload(
+    operation: OperationFamily,
+    protocol: ProtocolKind,
+    body: &[u8],
+) -> Option<String> {
+    let value = serde_json::from_slice::<serde_json::Value>(body).ok()?;
+    match (operation, protocol) {
+        (OperationFamily::ModelList, _) => None,
+
+        (OperationFamily::ModelGet, ProtocolKind::OpenAi) => {
+            json_pointer_string(&value, "/path/model")
+        }
+        (OperationFamily::ModelGet, ProtocolKind::Claude) => {
+            json_pointer_string(&value, "/path/model_id")
+        }
+        (OperationFamily::ModelGet, ProtocolKind::Gemini)
+        | (OperationFamily::ModelGet, ProtocolKind::GeminiNDJson) => {
+            json_pointer_string(&value, "/path/name")
+                .or_else(|| json_pointer_string(&value, "/path/model"))
+        }
+
+        (OperationFamily::CountToken, ProtocolKind::OpenAi)
+        | (OperationFamily::CountToken, ProtocolKind::Claude) => {
+            json_pointer_string(&value, "/model")
+                .or_else(|| json_pointer_string(&value, "/body/model"))
+        }
+        (OperationFamily::CountToken, ProtocolKind::Gemini)
+        | (OperationFamily::CountToken, ProtocolKind::GeminiNDJson) => {
+            json_pointer_string(&value, "/body/generate_content_request/model")
+                .or_else(|| json_pointer_string(&value, "/path/model"))
+        }
+
+        (OperationFamily::GenerateContent, ProtocolKind::OpenAi)
+        | (OperationFamily::StreamGenerateContent, ProtocolKind::OpenAi)
+        | (OperationFamily::GenerateContent, ProtocolKind::OpenAiChatCompletion)
+        | (OperationFamily::StreamGenerateContent, ProtocolKind::OpenAiChatCompletion)
+        | (OperationFamily::GenerateContent, ProtocolKind::Claude)
+        | (OperationFamily::StreamGenerateContent, ProtocolKind::Claude)
+        | (OperationFamily::Embedding, ProtocolKind::OpenAi)
+        | (OperationFamily::Compact, ProtocolKind::OpenAi) => json_pointer_string(&value, "/model")
+            .or_else(|| json_pointer_string(&value, "/body/model")),
+        (OperationFamily::GenerateContent, ProtocolKind::Gemini)
+        | (OperationFamily::GenerateContent, ProtocolKind::GeminiNDJson)
+        | (OperationFamily::StreamGenerateContent, ProtocolKind::Gemini)
+        | (OperationFamily::StreamGenerateContent, ProtocolKind::GeminiNDJson)
+        | (OperationFamily::Embedding, ProtocolKind::Gemini)
+        | (OperationFamily::Embedding, ProtocolKind::GeminiNDJson) => {
+            json_pointer_string(&value, "/path/model")
+        }
+        _ => None,
+    }
+}
+
+pub(super) fn usage_request_context_from_transform_request(
+    request: &TransformRequest,
+) -> UsageRequestContext {
+    UsageRequestContext {
+        operation: request.operation(),
+        protocol: request.protocol(),
+        model: extract_model_from_request(request),
+        body_for_estimate: serde_json::to_vec(request).ok(),
+    }
+}
+
+pub(super) fn usage_request_context_from_payload(
+    operation: OperationFamily,
+    protocol: ProtocolKind,
+    body: &[u8],
+) -> UsageRequestContext {
+    UsageRequestContext {
+        operation,
+        protocol,
+        model: extract_model_from_payload(operation, protocol, body),
+        body_for_estimate: Some(body.to_vec()),
+    }
 }
 
 pub(super) fn extract_model_from_request(request: &TransformRequest) -> Option<String> {
@@ -789,7 +884,7 @@ pub(super) fn normalize_usage_model(model: Option<String>) -> Option<String> {
 
 pub(super) struct UpstreamAndUsageEventInput<'a> {
     pub(super) auth: RequestAuthContext,
-    pub(super) request: &'a TransformRequest,
+    pub(super) request: &'a UsageRequestContext,
     pub(super) provider_id: Option<i64>,
     pub(super) credential_id: Option<i64>,
     pub(super) request_meta: Option<&'a UpstreamRequestMeta>,
@@ -818,7 +913,7 @@ pub(super) async fn enqueue_upstream_and_usage_event(
     } = input;
     let operation = format!("{:?}", request.operation());
     let protocol = format!("{:?}", request.protocol());
-    let request_model = normalize_usage_model(extract_model_from_request(request));
+    let request_model = normalize_usage_model(request.model.clone());
     let now_unix_ms = now_unix_ms_i64();
     let extracted_usage = local_response.and_then(extract_usage_from_local_response);
     let mask_sensitive_info = state.config.load().global.mask_sensitive_info;
@@ -875,7 +970,7 @@ pub(super) async fn enqueue_upstream_and_usage_event(
         extracted_usage.and_then(|value| value.cache_creation_input_tokens_1h);
 
     if request.operation() == OperationFamily::Embedding && input_tokens.is_none() {
-        input_tokens = estimate_embedding_input_tokens_from_request(state, request).await;
+        input_tokens = estimate_embedding_input_tokens_from_usage_request(state, request).await;
         output_tokens = output_tokens.or(Some(0));
     }
     if request.operation() == OperationFamily::CountToken && input_tokens.is_some() {

--- a/crates/gproxy-middleware/src/lib.rs
+++ b/crates/gproxy-middleware/src/lib.rs
@@ -27,7 +27,8 @@ pub use middleware::transform::response::{
     ResponseTransformLayer, ResponseTransformService, ResponseTransformServiceError,
 };
 pub use middleware::transform::{
-    decode_response_payload, transform_request, transform_request_payload, transform_response,
+    TransformLane, decode_request_payload, decode_response_payload, select_request_lane,
+    select_response_lane, transform_request, transform_request_payload, transform_response,
     transform_response_payload,
 };
 pub use middleware::usage::{

--- a/crates/gproxy-middleware/src/middleware/provider_prefix.rs
+++ b/crates/gproxy-middleware/src/middleware/provider_prefix.rs
@@ -11,18 +11,13 @@ use gproxy_protocol::claude::create_message::stream::ClaudeCreateMessageStreamEv
 use gproxy_protocol::claude::create_message::types::Model as ClaudeModel;
 use gproxy_protocol::openai::create_chat_completions::stream::ChatCompletionChunk;
 use gproxy_protocol::openai::create_response::stream::ResponseStreamEvent;
-use gproxy_protocol::openai::embeddings::types::OpenAiEmbeddingModel;
 use tower::{Layer, Service};
 
-use crate::middleware::transform::engine::{
-    decode_request_payload, decode_response_payload, encode_request_payload,
-    encode_response_payload,
-};
+use crate::middleware::transform::engine::{decode_response_payload, encode_response_payload};
 use crate::middleware::transform::error::MiddlewareTransformError;
 use crate::middleware::transform::kinds::{OperationFamily, ProtocolKind};
 use crate::middleware::transform::message::{
-    TransformBodyStream, TransformRequest, TransformRequestPayload, TransformResponse,
-    TransformResponsePayload,
+    TransformBodyStream, TransformRequestPayload, TransformResponse, TransformResponsePayload,
 };
 
 pub struct ProviderScopedRequest {
@@ -41,10 +36,8 @@ pub async fn extract_provider_from_request_payload(
     }
 
     let body = collect_body_bytes(input.body).await?;
-    let mut request = decode_request_payload(input.operation, input.protocol, body.as_slice())?;
-    let provider =
-        strip_provider_prefix_from_request(&mut request, input.operation, input.protocol)?;
-    let body = encode_request_payload(request)?;
+    let (provider, body) =
+        strip_provider_prefix_from_request_json(input.operation, input.protocol, body.as_slice())?;
 
     Ok(ProviderScopedRequest {
         request: TransformRequestPayload::from_bytes(
@@ -329,145 +322,220 @@ fn add_provider_prefix(value: &str, provider: &str) -> String {
     }
 }
 
-fn strip_provider_prefix_from_request(
-    request: &mut TransformRequest,
+fn strip_provider_prefix_from_request_json(
+    operation: OperationFamily,
+    protocol: ProtocolKind,
+    body: &[u8],
+) -> Result<(String, Vec<u8>), MiddlewareTransformError> {
+    let mut value: serde_json::Value =
+        serde_json::from_slice(body).map_err(|err| MiddlewareTransformError::JsonDecode {
+            kind: "request",
+            operation,
+            protocol,
+            message: err.to_string(),
+        })?;
+    let provider = strip_provider_prefix_from_request_value(&mut value, operation, protocol)?;
+    let encoded =
+        serde_json::to_vec(&value).map_err(|err| MiddlewareTransformError::JsonEncode {
+            kind: "request",
+            operation,
+            protocol,
+            message: err.to_string(),
+        })?;
+    Ok((provider, encoded))
+}
+
+fn strip_provider_prefix_from_request_value(
+    request: &mut serde_json::Value,
     operation: OperationFamily,
     protocol: ProtocolKind,
 ) -> Result<String, MiddlewareTransformError> {
     let mut capture = ProviderCapture::new();
 
-    match request {
-        TransformRequest::ModelListOpenAi(_)
-        | TransformRequest::ModelListClaude(_)
-        | TransformRequest::ModelListGemini(_) => {}
-        TransformRequest::ModelGetOpenAi(value) => {
-            value.path.model =
-                capture.strip(operation, protocol, "path.model", &value.path.model)?;
+    match (operation, protocol) {
+        (OperationFamily::ModelGet, ProtocolKind::OpenAi) => {
+            strip_required_string_field(
+                request,
+                &mut capture,
+                operation,
+                protocol,
+                "path.model",
+                "/path/model",
+                None,
+            )?;
         }
-        TransformRequest::ModelGetClaude(value) => {
-            value.path.model_id =
-                capture.strip(operation, protocol, "path.model_id", &value.path.model_id)?;
+        (OperationFamily::ModelGet, ProtocolKind::Claude) => {
+            strip_required_string_field(
+                request,
+                &mut capture,
+                operation,
+                protocol,
+                "path.model_id",
+                "/path/model_id",
+                None,
+            )?;
         }
-        TransformRequest::ModelGetGemini(value) => {
-            value.path.name = capture.strip(operation, protocol, "path.name", &value.path.name)?;
+        (OperationFamily::ModelGet, ProtocolKind::Gemini)
+        | (OperationFamily::ModelGet, ProtocolKind::GeminiNDJson) => {
+            strip_required_string_field(
+                request,
+                &mut capture,
+                operation,
+                protocol,
+                "path.name",
+                "/path/name",
+                None,
+            )?;
         }
-        TransformRequest::CountTokenOpenAi(value) => {
-            let Some(model) = value.body.model.as_ref() else {
-                return Err(MiddlewareTransformError::ProviderPrefix {
-                    message: "missing body.model for OpenAI count-tokens".to_string(),
-                });
-            };
-            value.body.model = Some(capture.strip(operation, protocol, "body.model", model)?);
-        }
-        TransformRequest::CountTokenClaude(value) => {
-            strip_provider_from_claude_model(
-                &mut value.body.model,
+        (OperationFamily::CountToken, ProtocolKind::OpenAi) => {
+            strip_required_string_field(
+                request,
                 &mut capture,
                 operation,
                 protocol,
                 "body.model",
+                "/body/model",
+                Some("missing body.model for OpenAI count-tokens"),
             )?;
         }
-        TransformRequest::CountTokenGemini(value) => {
-            value.path.model =
-                capture.strip(operation, protocol, "path.model", &value.path.model)?;
-            if let Some(generate_request) = value.body.generate_content_request.as_mut() {
-                generate_request.model = capture.strip(
-                    operation,
-                    protocol,
-                    "body.generate_content_request.model",
-                    &generate_request.model,
-                )?;
-            }
-        }
-        TransformRequest::GenerateContentOpenAiResponse(value)
-        | TransformRequest::StreamGenerateContentOpenAiResponse(value) => {
-            let Some(model) = value.body.model.as_ref() else {
-                return Err(MiddlewareTransformError::ProviderPrefix {
-                    message: "missing body.model for OpenAI responses".to_string(),
-                });
-            };
-            value.body.model = Some(capture.strip(operation, protocol, "body.model", model)?);
-        }
-        TransformRequest::GenerateContentOpenAiChatCompletions(value)
-        | TransformRequest::StreamGenerateContentOpenAiChatCompletions(value) => {
-            value.body.model =
-                capture.strip(operation, protocol, "body.model", &value.body.model)?;
-        }
-        TransformRequest::GenerateContentClaude(value)
-        | TransformRequest::StreamGenerateContentClaude(value) => {
-            strip_provider_from_claude_model(
-                &mut value.body.model,
+        (OperationFamily::CountToken, ProtocolKind::Claude) => {
+            strip_required_string_field(
+                request,
                 &mut capture,
                 operation,
                 protocol,
                 "body.model",
+                "/body/model",
+                None,
             )?;
         }
-        TransformRequest::GenerateContentGemini(value) => {
-            value.path.model =
-                capture.strip(operation, protocol, "path.model", &value.path.model)?;
+        (OperationFamily::CountToken, ProtocolKind::Gemini)
+        | (OperationFamily::CountToken, ProtocolKind::GeminiNDJson) => {
+            strip_required_string_field(
+                request,
+                &mut capture,
+                operation,
+                protocol,
+                "path.model",
+                "/path/model",
+                None,
+            )?;
+            strip_optional_string_field(
+                request,
+                &mut capture,
+                operation,
+                protocol,
+                "body.generate_content_request.model",
+                "/body/generate_content_request/model",
+            )?;
         }
-        TransformRequest::StreamGenerateContentGeminiSse(value)
-        | TransformRequest::StreamGenerateContentGeminiNdjson(value) => {
-            value.path.model =
-                capture.strip(operation, protocol, "path.model", &value.path.model)?;
-        }
-        TransformRequest::EmbeddingOpenAi(value) => {
-            strip_provider_from_openai_embedding_model(
-                &mut value.body.model,
+        (OperationFamily::GenerateContent, ProtocolKind::OpenAi)
+        | (OperationFamily::StreamGenerateContent, ProtocolKind::OpenAi) => {
+            strip_required_string_field(
+                request,
                 &mut capture,
                 operation,
                 protocol,
                 "body.model",
+                "/body/model",
+                Some("missing body.model for OpenAI responses"),
             )?;
         }
-        TransformRequest::EmbeddingGemini(value) => {
-            value.path.model =
-                capture.strip(operation, protocol, "path.model", &value.path.model)?;
+        (OperationFamily::GenerateContent, ProtocolKind::OpenAiChatCompletion)
+        | (OperationFamily::StreamGenerateContent, ProtocolKind::OpenAiChatCompletion)
+        | (OperationFamily::GenerateContent, ProtocolKind::Claude)
+        | (OperationFamily::StreamGenerateContent, ProtocolKind::Claude) => {
+            strip_required_string_field(
+                request,
+                &mut capture,
+                operation,
+                protocol,
+                "body.model",
+                "/body/model",
+                None,
+            )?;
         }
-        TransformRequest::CompactOpenAi(value) => {
-            value.body.model =
-                capture.strip(operation, protocol, "body.model", &value.body.model)?;
+        (OperationFamily::GenerateContent, ProtocolKind::Gemini)
+        | (OperationFamily::GenerateContent, ProtocolKind::GeminiNDJson)
+        | (OperationFamily::StreamGenerateContent, ProtocolKind::Gemini)
+        | (OperationFamily::StreamGenerateContent, ProtocolKind::GeminiNDJson)
+        | (OperationFamily::Embedding, ProtocolKind::Gemini)
+        | (OperationFamily::Embedding, ProtocolKind::GeminiNDJson) => {
+            strip_required_string_field(
+                request,
+                &mut capture,
+                operation,
+                protocol,
+                "path.model",
+                "/path/model",
+                None,
+            )?;
+        }
+        (OperationFamily::Embedding, ProtocolKind::OpenAi)
+        | (OperationFamily::Compact, ProtocolKind::OpenAi) => {
+            strip_required_string_field(
+                request,
+                &mut capture,
+                operation,
+                protocol,
+                "body.model",
+                "/body/model",
+                None,
+            )?;
+        }
+        _ => {
+            return Err(MiddlewareTransformError::Unsupported(
+                "provider prefix stripping is not implemented for this operation/protocol",
+            ));
         }
     }
 
     capture.finish(operation, protocol)
 }
 
-fn strip_provider_from_claude_model(
-    model: &mut ClaudeModel,
+fn strip_required_string_field(
+    value: &mut serde_json::Value,
     capture: &mut ProviderCapture,
     operation: OperationFamily,
     protocol: ProtocolKind,
     field: &'static str,
+    pointer: &'static str,
+    missing_message: Option<&'static str>,
 ) -> Result<(), MiddlewareTransformError> {
-    let ClaudeModel::Custom(value) = model else {
+    let Some(slot) = value.pointer_mut(pointer) else {
+        let message = missing_message
+            .map(ToOwned::to_owned)
+            .unwrap_or_else(|| format!("missing {field} for ({operation:?}, {protocol:?})"));
+        return Err(MiddlewareTransformError::ProviderPrefix { message });
+    };
+    let Some(raw) = slot.as_str() else {
         return Err(MiddlewareTransformError::ProviderPrefix {
-            message: format!(
-                "missing provider prefix in {field} for ({operation:?}, {protocol:?}): Claude known model has no provider segment",
-            ),
+            message: format!("invalid {field} for ({operation:?}, {protocol:?}): expected string",),
         });
     };
-    *value = capture.strip(operation, protocol, field, value)?;
+    let stripped = capture.strip(operation, protocol, field, raw)?;
+    *slot = serde_json::Value::String(stripped);
     Ok(())
 }
 
-fn strip_provider_from_openai_embedding_model(
-    model: &mut OpenAiEmbeddingModel,
+fn strip_optional_string_field(
+    value: &mut serde_json::Value,
     capture: &mut ProviderCapture,
     operation: OperationFamily,
     protocol: ProtocolKind,
     field: &'static str,
+    pointer: &'static str,
 ) -> Result<(), MiddlewareTransformError> {
-    let OpenAiEmbeddingModel::Custom(value) = model else {
+    let Some(slot) = value.pointer_mut(pointer) else {
+        return Ok(());
+    };
+    let Some(raw) = slot.as_str() else {
         return Err(MiddlewareTransformError::ProviderPrefix {
-            message: format!(
-                "missing provider prefix in {field} for ({operation:?}, {protocol:?}): known embedding model has no provider segment",
-            ),
+            message: format!("invalid {field} for ({operation:?}, {protocol:?}): expected string",),
         });
     };
-    *value = capture.strip(operation, protocol, field, value)?;
+    let stripped = capture.strip(operation, protocol, field, raw)?;
+    *slot = serde_json::Value::String(stripped);
     Ok(())
 }
 

--- a/crates/gproxy-middleware/src/middleware/request_model.rs
+++ b/crates/gproxy-middleware/src/middleware/request_model.rs
@@ -6,16 +6,12 @@ use std::task::{Context, Poll};
 
 use bytes::Bytes;
 use futures_util::StreamExt;
-use gproxy_protocol::claude::create_message::types::Model as ClaudeModel;
-use gproxy_protocol::openai::embeddings::types::OpenAiEmbeddingModel;
+use serde_json::Value;
 use tower::{Layer, Service};
 
-use crate::middleware::transform::engine::decode_request_payload;
 use crate::middleware::transform::error::MiddlewareTransformError;
-use crate::middleware::transform::kinds::OperationFamily;
-use crate::middleware::transform::message::{
-    TransformBodyStream, TransformRequest, TransformRequestPayload,
-};
+use crate::middleware::transform::kinds::{OperationFamily, ProtocolKind};
+use crate::middleware::transform::message::{TransformBodyStream, TransformRequestPayload};
 
 pub struct ModelScopedRequest {
     pub request: TransformRequestPayload,
@@ -33,8 +29,7 @@ pub async fn extract_model_from_request_payload(
     }
 
     let body = collect_body_bytes(input.body).await?;
-    let request = decode_request_payload(input.operation, input.protocol, body.as_slice())?;
-    let model = extract_model_from_request(&request);
+    let model = extract_model_from_json_payload(input.operation, input.protocol, body.as_slice())?;
 
     Ok(ModelScopedRequest {
         request: TransformRequestPayload::from_bytes(
@@ -117,64 +112,85 @@ where
     }
 }
 
-fn extract_model_from_request(request: &TransformRequest) -> Option<String> {
-    match request {
-        TransformRequest::ModelListOpenAi(_)
-        | TransformRequest::ModelListClaude(_)
-        | TransformRequest::ModelListGemini(_) => None,
+fn extract_model_from_json_payload(
+    operation: OperationFamily,
+    protocol: ProtocolKind,
+    body: &[u8],
+) -> Result<Option<String>, MiddlewareTransformError> {
+    let value: Value =
+        serde_json::from_slice(body).map_err(|err| MiddlewareTransformError::JsonDecode {
+            kind: "request",
+            operation,
+            protocol,
+            message: err.to_string(),
+        })?;
 
-        TransformRequest::ModelGetOpenAi(value) => Some(value.path.model.clone()),
-        TransformRequest::ModelGetClaude(value) => Some(value.path.model_id.clone()),
-        TransformRequest::ModelGetGemini(value) => Some(value.path.name.clone()),
+    Ok(match (operation, protocol) {
+        (OperationFamily::ModelList, _) => None,
 
-        TransformRequest::CountTokenOpenAi(value) => value.body.model.clone(),
-        TransformRequest::CountTokenClaude(value) => serialize_claude_model(&value.body.model),
-        TransformRequest::CountTokenGemini(value) => {
-            if let Some(generate_request) = value.body.generate_content_request.as_ref() {
-                Some(generate_request.model.clone())
-            } else {
-                Some(value.path.model.clone())
-            }
+        (OperationFamily::ModelGet, ProtocolKind::OpenAi) => {
+            json_pointer_string(&value, "/path/model")
+        }
+        (OperationFamily::ModelGet, ProtocolKind::Claude) => {
+            json_pointer_string(&value, "/path/model_id")
+        }
+        (OperationFamily::ModelGet, ProtocolKind::Gemini)
+        | (OperationFamily::ModelGet, ProtocolKind::GeminiNDJson) => {
+            json_pointer_string(&value, "/path/name")
         }
 
-        TransformRequest::GenerateContentOpenAiResponse(value)
-        | TransformRequest::StreamGenerateContentOpenAiResponse(value) => value.body.model.clone(),
-
-        TransformRequest::GenerateContentOpenAiChatCompletions(value)
-        | TransformRequest::StreamGenerateContentOpenAiChatCompletions(value) => {
-            Some(value.body.model.clone())
+        (OperationFamily::CountToken, ProtocolKind::OpenAi) => {
+            json_pointer_string(&value, "/body/model")
+        }
+        (OperationFamily::CountToken, ProtocolKind::Claude) => {
+            json_pointer_string(&value, "/body/model")
+        }
+        (OperationFamily::CountToken, ProtocolKind::Gemini)
+        | (OperationFamily::CountToken, ProtocolKind::GeminiNDJson) => {
+            json_pointer_string(&value, "/body/generate_content_request/model")
+                .or_else(|| json_pointer_string(&value, "/path/model"))
         }
 
-        TransformRequest::GenerateContentClaude(value)
-        | TransformRequest::StreamGenerateContentClaude(value) => {
-            serialize_claude_model(&value.body.model)
+        (OperationFamily::GenerateContent, ProtocolKind::OpenAi)
+        | (OperationFamily::StreamGenerateContent, ProtocolKind::OpenAi) => {
+            json_pointer_string(&value, "/body/model")
+        }
+        (OperationFamily::GenerateContent, ProtocolKind::OpenAiChatCompletion)
+        | (OperationFamily::StreamGenerateContent, ProtocolKind::OpenAiChatCompletion) => {
+            json_pointer_string(&value, "/body/model")
+        }
+        (OperationFamily::GenerateContent, ProtocolKind::Claude)
+        | (OperationFamily::StreamGenerateContent, ProtocolKind::Claude) => {
+            json_pointer_string(&value, "/body/model")
+        }
+        (OperationFamily::GenerateContent, ProtocolKind::Gemini)
+        | (OperationFamily::GenerateContent, ProtocolKind::GeminiNDJson)
+        | (OperationFamily::StreamGenerateContent, ProtocolKind::Gemini)
+        | (OperationFamily::StreamGenerateContent, ProtocolKind::GeminiNDJson) => {
+            json_pointer_string(&value, "/path/model")
         }
 
-        TransformRequest::GenerateContentGemini(value) => Some(value.path.model.clone()),
-        TransformRequest::StreamGenerateContentGeminiSse(value)
-        | TransformRequest::StreamGenerateContentGeminiNdjson(value) => {
-            Some(value.path.model.clone())
+        (OperationFamily::Embedding, ProtocolKind::OpenAi) => {
+            json_pointer_string(&value, "/body/model")
+        }
+        (OperationFamily::Embedding, ProtocolKind::Gemini)
+        | (OperationFamily::Embedding, ProtocolKind::GeminiNDJson) => {
+            json_pointer_string(&value, "/path/model")
         }
 
-        TransformRequest::EmbeddingOpenAi(value) => {
-            serialize_openai_embedding_model(&value.body.model)
+        (OperationFamily::Compact, ProtocolKind::OpenAi) => {
+            json_pointer_string(&value, "/body/model")
         }
-        TransformRequest::EmbeddingGemini(value) => Some(value.path.model.clone()),
 
-        TransformRequest::CompactOpenAi(value) => Some(value.body.model.clone()),
-    }
+        _ => None,
+    })
 }
 
-fn serialize_claude_model(model: &ClaudeModel) -> Option<String> {
-    serde_json::to_value(model)
-        .ok()
-        .and_then(|value| value.as_str().map(ToOwned::to_owned))
-}
-
-fn serialize_openai_embedding_model(model: &OpenAiEmbeddingModel) -> Option<String> {
-    serde_json::to_value(model)
-        .ok()
-        .and_then(|value| value.as_str().map(ToOwned::to_owned))
+fn json_pointer_string(value: &Value, pointer: &str) -> Option<String> {
+    value
+        .pointer(pointer)
+        .and_then(Value::as_str)
+        .map(ToOwned::to_owned)
 }
 
 async fn collect_body_bytes(

--- a/crates/gproxy-middleware/src/middleware/transform/engine.rs
+++ b/crates/gproxy-middleware/src/middleware/transform/engine.rs
@@ -93,6 +93,28 @@ use super::message::{
     TransformResponsePayload, TransformRoute,
 };
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TransformLane {
+    Raw,
+    Typed,
+}
+
+pub fn select_request_lane(route: TransformRoute) -> TransformLane {
+    if route.is_passthrough() {
+        TransformLane::Raw
+    } else {
+        TransformLane::Typed
+    }
+}
+
+pub fn select_response_lane(route: TransformRoute) -> TransformLane {
+    if route.is_passthrough() {
+        TransformLane::Raw
+    } else {
+        TransformLane::Typed
+    }
+}
+
 fn decode_json<T: DeserializeOwned>(
     kind: &'static str,
     operation: OperationFamily,
@@ -135,7 +157,7 @@ fn bytes_to_body_stream(bytes: Vec<u8>) -> TransformBodyStream {
     Box::pin(stream::once(async move { Ok(Bytes::from(bytes)) }))
 }
 
-pub(crate) fn decode_request_payload(
+pub fn decode_request_payload(
     operation: OperationFamily,
     protocol: ProtocolKind,
     body: &[u8],
@@ -1645,7 +1667,7 @@ pub async fn transform_request_payload(
         });
     }
 
-    if route.is_passthrough() {
+    if select_request_lane(route) == TransformLane::Raw {
         return Ok(input);
     }
 
@@ -1677,7 +1699,7 @@ pub async fn transform_response_payload(
         });
     }
 
-    if route.is_passthrough() {
+    if select_response_lane(route) == TransformLane::Raw {
         return Ok(input);
     }
 

--- a/crates/gproxy-middleware/src/middleware/transform/mod.rs
+++ b/crates/gproxy-middleware/src/middleware/transform/mod.rs
@@ -6,7 +6,8 @@ pub mod request;
 pub mod response;
 
 pub use engine::{
-    decode_response_payload, transform_request, transform_request_payload, transform_response,
+    TransformLane, decode_request_payload, decode_response_payload, select_request_lane,
+    select_response_lane, transform_request, transform_request_payload, transform_response,
     transform_response_payload,
 };
 pub use error::MiddlewareTransformError;

--- a/crates/gproxy-provider/src/channels/aistudio/mod.rs
+++ b/crates/gproxy-provider/src/channels/aistudio/mod.rs
@@ -7,4 +7,4 @@ pub mod upstream;
 pub use credential::AiStudioCredential;
 pub use dispatch::default_dispatch_table;
 pub use settings::AiStudioSettings;
-pub use upstream::execute_aistudio_with_retry;
+pub use upstream::{execute_aistudio_payload_with_retry, execute_aistudio_with_retry};

--- a/crates/gproxy-provider/src/channels/aistudio/upstream.rs
+++ b/crates/gproxy-provider/src/channels/aistudio/upstream.rs
@@ -1,9 +1,10 @@
+use serde_json::Value;
 use wreq::{Client as WreqClient, Method as WreqMethod};
 
 use crate::channels::retry::{
-    CredentialRetryDecision, cache_affinity_hint_from_transform_request,
-    configured_pick_mode_uses_cache, credential_pick_mode,
-    retry_with_eligible_credentials_with_affinity,
+    CacheAffinityProtocol, CredentialRetryDecision, cache_affinity_hint_from_transform_request,
+    cache_affinity_protocol_from_transform_request, configured_pick_mode_uses_cache,
+    credential_pick_mode, retry_with_eligible_credentials_with_affinity,
 };
 use crate::channels::upstream::{UpstreamError, UpstreamResponse};
 use crate::channels::utils::{
@@ -15,6 +16,7 @@ use crate::channels::{BuiltinChannelCredential, ChannelCredential};
 use crate::credential::ChannelCredentialStateStore;
 use crate::credential_state::CredentialStateManager;
 use crate::provider::ProviderDefinition;
+use gproxy_middleware::{OperationFamily, ProtocolKind};
 
 pub async fn execute_aistudio_with_retry(
     client: &WreqClient,
@@ -23,7 +25,49 @@ pub async fn execute_aistudio_with_retry(
     request: &gproxy_middleware::TransformRequest,
     now_unix_ms: u64,
 ) -> Result<UpstreamResponse, UpstreamError> {
+    let cache_protocol = cache_affinity_protocol_from_transform_request(request);
     let prepared = AiStudioPreparedRequest::from_transform_request(request)?;
+    execute_aistudio_with_prepared(
+        client,
+        provider,
+        credential_states,
+        prepared,
+        cache_protocol,
+        now_unix_ms,
+    )
+    .await
+}
+
+pub async fn execute_aistudio_payload_with_retry(
+    client: &WreqClient,
+    provider: &ProviderDefinition,
+    credential_states: &ChannelCredentialStateStore,
+    operation: OperationFamily,
+    protocol: ProtocolKind,
+    body: &[u8],
+    now_unix_ms: u64,
+) -> Result<UpstreamResponse, UpstreamError> {
+    let prepared = AiStudioPreparedRequest::from_payload(operation, protocol, body)?;
+    let cache_protocol = cache_affinity_protocol_from_operation_protocol(operation, protocol);
+    execute_aistudio_with_prepared(
+        client,
+        provider,
+        credential_states,
+        prepared,
+        cache_protocol,
+        now_unix_ms,
+    )
+    .await
+}
+
+async fn execute_aistudio_with_prepared(
+    client: &WreqClient,
+    provider: &ProviderDefinition,
+    credential_states: &ChannelCredentialStateStore,
+    prepared: AiStudioPreparedRequest,
+    cache_protocol: Option<CacheAffinityProtocol>,
+    now_unix_ms: u64,
+) -> Result<UpstreamResponse, UpstreamError> {
     let base_url = provider.settings.base_url().trim();
     if base_url.is_empty() {
         return Err(UpstreamError::InvalidBaseUrl);
@@ -42,15 +86,13 @@ pub async fn execute_aistudio_with_retry(
     let user_agent_template =
         resolve_user_agent_or_else(provider.settings.user_agent(), default_gproxy_user_agent);
     let cache_affinity_hint = if configured_pick_mode_uses_cache(provider.credential_pick_mode) {
-        crate::channels::retry::cache_affinity_protocol_from_transform_request(request).and_then(
-            |protocol| {
-                cache_affinity_hint_from_transform_request(
-                    protocol,
-                    prepared.model.as_deref(),
-                    prepared.body.as_deref(),
-                )
-            },
-        )
+        cache_protocol.and_then(|protocol| {
+            cache_affinity_hint_from_transform_request(
+                protocol,
+                prepared.model.as_deref(),
+                prepared.body.as_deref(),
+            )
+        })
     } else {
         None
     };
@@ -214,6 +256,24 @@ pub async fn execute_aistudio_with_retry(
     .await
 }
 
+fn cache_affinity_protocol_from_operation_protocol(
+    operation: OperationFamily,
+    protocol: ProtocolKind,
+) -> Option<CacheAffinityProtocol> {
+    match (operation, protocol) {
+        (OperationFamily::GenerateContent, ProtocolKind::Gemini)
+        | (OperationFamily::StreamGenerateContent, ProtocolKind::Gemini)
+        | (OperationFamily::StreamGenerateContent, ProtocolKind::GeminiNDJson) => {
+            Some(CacheAffinityProtocol::GeminiGenerateContent)
+        }
+        (OperationFamily::GenerateContent, ProtocolKind::OpenAiChatCompletion)
+        | (OperationFamily::StreamGenerateContent, ProtocolKind::OpenAiChatCompletion) => {
+            Some(CacheAffinityProtocol::OpenAiChatCompletions)
+        }
+        _ => None,
+    }
+}
+
 #[derive(Debug, Clone, Copy)]
 enum AuthScheme {
     Bearer,
@@ -375,6 +435,130 @@ impl AiStudioPreparedRequest {
                 model: Some(value.body.model.clone()),
                 auth_scheme: AuthScheme::Bearer,
             }),
+            _ => Err(UpstreamError::UnsupportedRequest),
+        }
+    }
+
+    fn from_payload(
+        operation: OperationFamily,
+        protocol: ProtocolKind,
+        body: &[u8],
+    ) -> Result<Self, UpstreamError> {
+        fn json_pointer_string(value: &Value, pointer: &str) -> Option<String> {
+            value
+                .pointer(pointer)
+                .and_then(Value::as_str)
+                .map(ToOwned::to_owned)
+        }
+
+        fn parse_gemini_payload_wrapper(
+            payload: &[u8],
+        ) -> Result<(String, Value, Option<String>), UpstreamError> {
+            let value = serde_json::from_slice::<Value>(payload)
+                .map_err(|err| UpstreamError::SerializeRequest(err.to_string()))?;
+            let Some(model) = value
+                .pointer("/path/model")
+                .and_then(Value::as_str)
+                .map(ToOwned::to_owned)
+            else {
+                return Err(UpstreamError::SerializeRequest(
+                    "missing path.model in Gemini payload".to_string(),
+                ));
+            };
+            let Some(body_value) = value.get("body").cloned() else {
+                return Err(UpstreamError::SerializeRequest(
+                    "missing body in Gemini payload".to_string(),
+                ));
+            };
+            let alt = value
+                .pointer("/query/alt")
+                .and_then(Value::as_str)
+                .map(ToOwned::to_owned);
+            Ok((model, body_value, alt))
+        }
+
+        match (operation, protocol) {
+            (OperationFamily::CountToken, ProtocolKind::Gemini) => {
+                let (model, body_value, _) = parse_gemini_payload_wrapper(body)?;
+                let model = normalize_gemini_model_name(model.as_str());
+                Ok(Self {
+                    method: WreqMethod::POST,
+                    path: format!("/v1beta/{model}:countTokens"),
+                    query: None,
+                    body: Some(
+                        serde_json::to_vec(&body_value)
+                            .map_err(|err| UpstreamError::SerializeRequest(err.to_string()))?,
+                    ),
+                    model: Some(model),
+                    auth_scheme: AuthScheme::XGoogApiKey,
+                })
+            }
+            (OperationFamily::GenerateContent, ProtocolKind::Gemini) => {
+                let (model, body_value, _) = parse_gemini_payload_wrapper(body)?;
+                let model = normalize_gemini_model_name(model.as_str());
+                Ok(Self {
+                    method: WreqMethod::POST,
+                    path: format!("/v1beta/{model}:generateContent"),
+                    query: None,
+                    body: Some(
+                        serde_json::to_vec(&body_value)
+                            .map_err(|err| UpstreamError::SerializeRequest(err.to_string()))?,
+                    ),
+                    model: Some(model),
+                    auth_scheme: AuthScheme::XGoogApiKey,
+                })
+            }
+            (OperationFamily::StreamGenerateContent, ProtocolKind::Gemini)
+            | (OperationFamily::StreamGenerateContent, ProtocolKind::GeminiNDJson) => {
+                let (model, body_value, alt) = parse_gemini_payload_wrapper(body)?;
+                let model = normalize_gemini_model_name(model.as_str());
+                let query = match protocol {
+                    ProtocolKind::Gemini => {
+                        Some(format!("alt={}", alt.unwrap_or_else(|| "sse".to_string())))
+                    }
+                    ProtocolKind::GeminiNDJson => alt.map(|value| format!("alt={value}")),
+                    _ => None,
+                };
+                Ok(Self {
+                    method: WreqMethod::POST,
+                    path: format!("/v1beta/{model}:streamGenerateContent"),
+                    query,
+                    body: Some(
+                        serde_json::to_vec(&body_value)
+                            .map_err(|err| UpstreamError::SerializeRequest(err.to_string()))?,
+                    ),
+                    model: Some(model),
+                    auth_scheme: AuthScheme::XGoogApiKey,
+                })
+            }
+            (OperationFamily::Embedding, ProtocolKind::Gemini) => {
+                let (model, body_value, _) = parse_gemini_payload_wrapper(body)?;
+                let model = normalize_gemini_model_name(model.as_str());
+                Ok(Self {
+                    method: WreqMethod::POST,
+                    path: format!("/v1beta/{model}:embedContent"),
+                    query: None,
+                    body: Some(
+                        serde_json::to_vec(&body_value)
+                            .map_err(|err| UpstreamError::SerializeRequest(err.to_string()))?,
+                    ),
+                    model: Some(model),
+                    auth_scheme: AuthScheme::XGoogApiKey,
+                })
+            }
+            (OperationFamily::GenerateContent, ProtocolKind::OpenAiChatCompletion)
+            | (OperationFamily::StreamGenerateContent, ProtocolKind::OpenAiChatCompletion) => {
+                Ok(Self {
+                    method: WreqMethod::POST,
+                    path: "/v1beta/openai/chat/completions".to_string(),
+                    query: None,
+                    body: Some(body.to_vec()),
+                    model: serde_json::from_slice::<Value>(body)
+                        .ok()
+                        .and_then(|value| json_pointer_string(&value, "/model")),
+                    auth_scheme: AuthScheme::Bearer,
+                })
+            }
             _ => Err(UpstreamError::UnsupportedRequest),
         }
     }

--- a/crates/gproxy-provider/src/channels/antigravity/mod.rs
+++ b/crates/gproxy-provider/src/channels/antigravity/mod.rs
@@ -13,7 +13,7 @@ pub use oauth::{
 };
 pub use settings::AntigravitySettings;
 pub use upstream::{
-    execute_antigravity_upstream_usage_with_retry, execute_antigravity_with_retry,
-    normalize_antigravity_upstream_response_body,
+    execute_antigravity_payload_with_retry, execute_antigravity_upstream_usage_with_retry,
+    execute_antigravity_with_retry, normalize_antigravity_upstream_response_body,
     normalize_antigravity_upstream_stream_ndjson_chunk,
 };

--- a/crates/gproxy-provider/src/channels/antigravity/upstream.rs
+++ b/crates/gproxy-provider/src/channels/antigravity/upstream.rs
@@ -1,6 +1,6 @@
 use std::time::{SystemTime, UNIX_EPOCH};
 
-use gproxy_middleware::{TransformRequest, TransformResponse};
+use gproxy_middleware::{OperationFamily, ProtocolKind, TransformRequest, TransformResponse};
 use serde_json::{Map, Value, json};
 use wreq::{Client as WreqClient, Method as WreqMethod, Response as WreqResponse};
 
@@ -25,6 +25,8 @@ use crate::channels::{BuiltinChannelCredential, ChannelCredential};
 use crate::credential::ChannelCredentialStateStore;
 use crate::credential_state::CredentialStateManager;
 use crate::provider::ProviderDefinition;
+
+type ParsedGeminiPayload = (Option<String>, Option<Value>, Option<String>);
 
 fn is_antigravity_auth_failure(status_code: u16) -> bool {
     status_code == 401
@@ -67,6 +69,83 @@ pub async fn execute_antigravity_with_retry(
     }
 
     let prepared = AntigravityPreparedRequest::from_transform_request(request)?;
+    let cache_affinity_hint = if configured_pick_mode_uses_cache(provider.credential_pick_mode) {
+        crate::channels::retry::cache_affinity_protocol_from_transform_request(request).and_then(
+            |protocol| {
+                cache_affinity_hint_from_transform_request(
+                    protocol,
+                    prepared.model.as_deref(),
+                    prepared
+                        .body
+                        .as_ref()
+                        .and_then(|value| serde_json::to_vec(value).ok())
+                        .as_deref(),
+                )
+            },
+        )
+    } else {
+        None
+    };
+    execute_antigravity_with_prepared(
+        client,
+        provider,
+        credential_states,
+        prepared,
+        now_unix_ms,
+        cache_affinity_hint,
+    )
+    .await
+}
+
+pub async fn execute_antigravity_payload_with_retry(
+    client: &WreqClient,
+    provider: &ProviderDefinition,
+    credential_states: &ChannelCredentialStateStore,
+    operation: OperationFamily,
+    protocol: ProtocolKind,
+    body: &[u8],
+    now_unix_ms: u64,
+) -> Result<UpstreamResponse, UpstreamError> {
+    if (operation, protocol) == (OperationFamily::CountToken, ProtocolKind::Gemini) {
+        let payload_value = serde_json::from_slice::<Value>(body)
+            .map_err(|err| UpstreamError::SerializeRequest(err.to_string()))?;
+        let payload = payload_value.get("body").cloned().unwrap_or(payload_value);
+        let text = collect_count_text(&payload);
+        let total_tokens = (text.chars().count() as u64).div_ceil(4);
+        let response_json = json!({
+            "stats_code": 200,
+            "headers": {},
+            "body": {
+                "totalTokens": total_tokens,
+            }
+        });
+        let response = serde_json::from_value(response_json)
+            .map_err(|err| UpstreamError::SerializeRequest(err.to_string()))?;
+        return Ok(UpstreamResponse::from_local(
+            TransformResponse::CountTokenGemini(response),
+        ));
+    }
+
+    let prepared = AntigravityPreparedRequest::from_payload(operation, protocol, body)?;
+    execute_antigravity_with_prepared(
+        client,
+        provider,
+        credential_states,
+        prepared,
+        now_unix_ms,
+        None,
+    )
+    .await
+}
+
+async fn execute_antigravity_with_prepared(
+    client: &WreqClient,
+    provider: &ProviderDefinition,
+    credential_states: &ChannelCredentialStateStore,
+    prepared: AntigravityPreparedRequest,
+    now_unix_ms: u64,
+    cache_affinity_hint: Option<crate::channels::retry::CacheAffinityHint>,
+) -> Result<UpstreamResponse, UpstreamError> {
     let base_url = provider.settings.base_url().trim();
     if base_url.is_empty() {
         return Err(UpstreamError::InvalidBaseUrl);
@@ -82,23 +161,6 @@ pub async fn execute_antigravity_with_retry(
     let base_url_template = base_url.to_string();
     let user_agent_template =
         resolve_user_agent_or_default(provider.settings.user_agent(), ANTIGRAVITY_USER_AGENT);
-    let affinity_body_template = prepared
-        .body
-        .as_ref()
-        .and_then(|body| serde_json::to_vec(body).ok());
-    let cache_affinity_hint = if configured_pick_mode_uses_cache(provider.credential_pick_mode) {
-        crate::channels::retry::cache_affinity_protocol_from_transform_request(request).and_then(
-            |protocol| {
-                cache_affinity_hint_from_transform_request(
-                    protocol,
-                    prepared.model.as_deref(),
-                    affinity_body_template.as_deref(),
-                )
-            },
-        )
-    } else {
-        None
-    };
     let pick_mode =
         credential_pick_mode(provider.credential_pick_mode, cache_affinity_hint.as_ref());
 
@@ -866,6 +928,155 @@ impl AntigravityPreparedRequest {
                             .map_err(|err| UpstreamError::SerializeRequest(err.to_string()))?,
                     ),
                     model: Some(normalize_model_id(value.path.model.as_str())),
+                    kind: AntigravityRequestKind::Forward {
+                        requires_project: false,
+                        request_type: None,
+                    },
+                })
+            }
+            _ => Err(UpstreamError::UnsupportedRequest),
+        }
+    }
+
+    fn from_payload(
+        operation: OperationFamily,
+        protocol: ProtocolKind,
+        body: &[u8],
+    ) -> Result<Self, UpstreamError> {
+        fn parse_gemini_payload_wrapper(
+            payload: &[u8],
+        ) -> Result<ParsedGeminiPayload, UpstreamError> {
+            let value = serde_json::from_slice::<Value>(payload)
+                .map_err(|err| UpstreamError::SerializeRequest(err.to_string()))?;
+            let model = value
+                .pointer("/path/model")
+                .or_else(|| value.pointer("/path/name"))
+                .and_then(Value::as_str)
+                .map(ToOwned::to_owned);
+            let body_value = value.get("body").cloned();
+            let alt = value
+                .pointer("/query/alt")
+                .and_then(Value::as_str)
+                .map(ToOwned::to_owned);
+            Ok((model, body_value, alt))
+        }
+
+        match (operation, protocol) {
+            (OperationFamily::ModelList, ProtocolKind::Gemini) => {
+                let payload = serde_json::from_slice::<Value>(body)
+                    .map_err(|err| UpstreamError::SerializeRequest(err.to_string()))?;
+                let page_size = payload
+                    .pointer("/query/page_size")
+                    .and_then(Value::as_u64)
+                    .map(|value| value as u32);
+                let page_token = payload
+                    .pointer("/query/page_token")
+                    .and_then(Value::as_str)
+                    .map(ToOwned::to_owned);
+                Ok(Self {
+                    method: WreqMethod::POST,
+                    path: "/v1internal:fetchAvailableModels".to_string(),
+                    query: gemini_model_list_query_string(page_size, page_token.as_deref()),
+                    body: Some(json!({})),
+                    model: None,
+                    kind: AntigravityRequestKind::ModelList {
+                        page_size,
+                        page_token,
+                    },
+                })
+            }
+            (OperationFamily::ModelGet, ProtocolKind::Gemini) => {
+                let payload = serde_json::from_slice::<Value>(body)
+                    .map_err(|err| UpstreamError::SerializeRequest(err.to_string()))?;
+                let Some(target) = payload
+                    .pointer("/path/name")
+                    .or_else(|| payload.pointer("/path/model"))
+                    .and_then(Value::as_str)
+                    .map(ToOwned::to_owned)
+                else {
+                    return Err(UpstreamError::SerializeRequest(
+                        "missing path.name in antigravity model_get payload".to_string(),
+                    ));
+                };
+                Ok(Self {
+                    method: WreqMethod::POST,
+                    path: "/v1internal:fetchAvailableModels".to_string(),
+                    query: None,
+                    body: Some(json!({})),
+                    model: Some(normalize_model_id(target.as_str())),
+                    kind: AntigravityRequestKind::ModelGet {
+                        target: normalize_model_name(target.as_str()),
+                    },
+                })
+            }
+            (OperationFamily::GenerateContent, ProtocolKind::Gemini) => {
+                let (model, body_value, _) = parse_gemini_payload_wrapper(body)?;
+                let Some(model) = model else {
+                    return Err(UpstreamError::SerializeRequest(
+                        "missing path.model in antigravity generate payload".to_string(),
+                    ));
+                };
+                let Some(body_value) = body_value else {
+                    return Err(UpstreamError::SerializeRequest(
+                        "missing body in antigravity generate payload".to_string(),
+                    ));
+                };
+                Ok(Self {
+                    method: WreqMethod::POST,
+                    path: "/v1internal:generateContent".to_string(),
+                    query: None,
+                    body: Some(body_value),
+                    model: Some(normalize_model_id(model.as_str())),
+                    kind: AntigravityRequestKind::Forward {
+                        requires_project: true,
+                        request_type: None,
+                    },
+                })
+            }
+            (OperationFamily::StreamGenerateContent, ProtocolKind::Gemini)
+            | (OperationFamily::StreamGenerateContent, ProtocolKind::GeminiNDJson) => {
+                let (model, body_value, alt) = parse_gemini_payload_wrapper(body)?;
+                let Some(model) = model else {
+                    return Err(UpstreamError::SerializeRequest(
+                        "missing path.model in antigravity stream payload".to_string(),
+                    ));
+                };
+                let Some(body_value) = body_value else {
+                    return Err(UpstreamError::SerializeRequest(
+                        "missing body in antigravity stream payload".to_string(),
+                    ));
+                };
+                Ok(Self {
+                    method: WreqMethod::POST,
+                    path: "/v1internal:streamGenerateContent".to_string(),
+                    query: Some(format!("alt={}", alt.unwrap_or_else(|| "sse".to_string()))),
+                    body: Some(body_value),
+                    model: Some(normalize_model_id(model.as_str())),
+                    kind: AntigravityRequestKind::Forward {
+                        requires_project: true,
+                        request_type: None,
+                    },
+                })
+            }
+            (OperationFamily::Embedding, ProtocolKind::Gemini) => {
+                let (model, body_value, _) = parse_gemini_payload_wrapper(body)?;
+                let Some(model) = model else {
+                    return Err(UpstreamError::SerializeRequest(
+                        "missing path.model in antigravity embedding payload".to_string(),
+                    ));
+                };
+                let Some(body_value) = body_value else {
+                    return Err(UpstreamError::SerializeRequest(
+                        "missing body in antigravity embedding payload".to_string(),
+                    ));
+                };
+                let model_name = normalize_model_name(model.as_str());
+                Ok(Self {
+                    method: WreqMethod::POST,
+                    path: format!("/v1beta/{model_name}:embedContent"),
+                    query: None,
+                    body: Some(body_value),
+                    model: Some(normalize_model_id(model.as_str())),
                     kind: AntigravityRequestKind::Forward {
                         requires_project: false,
                         request_type: None,

--- a/crates/gproxy-provider/src/channels/claude/mod.rs
+++ b/crates/gproxy-provider/src/channels/claude/mod.rs
@@ -7,4 +7,4 @@ pub mod upstream;
 pub use credential::ClaudeCredential;
 pub use dispatch::default_dispatch_table;
 pub use settings::ClaudeSettings;
-pub use upstream::execute_claude_with_retry;
+pub use upstream::{execute_claude_payload_with_retry, execute_claude_with_retry};

--- a/crates/gproxy-provider/src/channels/claude/upstream.rs
+++ b/crates/gproxy-provider/src/channels/claude/upstream.rs
@@ -1,12 +1,13 @@
+use serde_json::Value;
 use wreq::{Client as WreqClient, Method as WreqMethod};
 
 use crate::channels::cache_control::{
     CacheBreakpointRule, apply_magic_string_cache_control_triggers, ensure_cache_breakpoint_rules,
 };
 use crate::channels::retry::{
-    CredentialRetryDecision, cache_affinity_hint_from_transform_request,
-    configured_pick_mode_uses_cache, credential_pick_mode,
-    retry_with_eligible_credentials_with_affinity,
+    CacheAffinityProtocol, CredentialRetryDecision, cache_affinity_hint_from_transform_request,
+    cache_affinity_protocol_from_transform_request, configured_pick_mode_uses_cache,
+    credential_pick_mode, retry_with_eligible_credentials_with_affinity,
 };
 use crate::channels::upstream::{UpstreamError, UpstreamResponse};
 use crate::channels::utils::{
@@ -19,6 +20,7 @@ use crate::channels::{BuiltinChannelCredential, ChannelCredential};
 use crate::credential::ChannelCredentialStateStore;
 use crate::credential_state::CredentialStateManager;
 use crate::provider::ProviderDefinition;
+use gproxy_middleware::{OperationFamily, ProtocolKind};
 
 const ANTHROPIC_DEFAULT_VERSION: &str = "2023-06-01";
 const BETA_QUERY_KEY: &str = "beta";
@@ -31,10 +33,57 @@ pub async fn execute_claude_with_retry(
     request: &gproxy_middleware::TransformRequest,
     now_unix_ms: u64,
 ) -> Result<UpstreamResponse, UpstreamError> {
+    let cache_protocol = cache_affinity_protocol_from_transform_request(request);
     let prepared = ClaudePreparedRequest::from_transform_request(
         request,
         provider.settings.cache_breakpoints(),
     )?;
+    execute_claude_with_prepared(
+        client,
+        provider,
+        credential_states,
+        prepared,
+        cache_protocol,
+        now_unix_ms,
+    )
+    .await
+}
+
+pub async fn execute_claude_payload_with_retry(
+    client: &WreqClient,
+    provider: &ProviderDefinition,
+    credential_states: &ChannelCredentialStateStore,
+    operation: OperationFamily,
+    protocol: ProtocolKind,
+    body: &[u8],
+    now_unix_ms: u64,
+) -> Result<UpstreamResponse, UpstreamError> {
+    let prepared = ClaudePreparedRequest::from_payload(
+        operation,
+        protocol,
+        body,
+        provider.settings.cache_breakpoints(),
+    )?;
+    let cache_protocol = cache_affinity_protocol_from_operation_protocol(operation, protocol);
+    execute_claude_with_prepared(
+        client,
+        provider,
+        credential_states,
+        prepared,
+        cache_protocol,
+        now_unix_ms,
+    )
+    .await
+}
+
+async fn execute_claude_with_prepared(
+    client: &WreqClient,
+    provider: &ProviderDefinition,
+    credential_states: &ChannelCredentialStateStore,
+    prepared: ClaudePreparedRequest,
+    cache_protocol: Option<CacheAffinityProtocol>,
+    now_unix_ms: u64,
+) -> Result<UpstreamResponse, UpstreamError> {
     let base_url = provider.settings.base_url().trim();
     if base_url.is_empty() {
         return Err(UpstreamError::InvalidBaseUrl);
@@ -50,15 +99,13 @@ pub async fn execute_claude_with_retry(
     let user_agent_template =
         resolve_user_agent_or_else(provider.settings.user_agent(), default_gproxy_user_agent);
     let cache_affinity_hint = if configured_pick_mode_uses_cache(provider.credential_pick_mode) {
-        crate::channels::retry::cache_affinity_protocol_from_transform_request(request).and_then(
-            |protocol| {
-                cache_affinity_hint_from_transform_request(
-                    protocol,
-                    prepared.model.as_deref(),
-                    prepared.body.as_deref(),
-                )
-            },
-        )
+        cache_protocol.and_then(|protocol| {
+            cache_affinity_hint_from_transform_request(
+                protocol,
+                prepared.model.as_deref(),
+                prepared.body.as_deref(),
+            )
+        })
     } else {
         None
     };
@@ -207,6 +254,19 @@ pub async fn execute_claude_with_retry(
         },
     )
     .await
+}
+
+fn cache_affinity_protocol_from_operation_protocol(
+    operation: OperationFamily,
+    protocol: ProtocolKind,
+) -> Option<CacheAffinityProtocol> {
+    match (operation, protocol) {
+        (OperationFamily::GenerateContent, ProtocolKind::Claude)
+        | (OperationFamily::StreamGenerateContent, ProtocolKind::Claude) => {
+            Some(CacheAffinityProtocol::ClaudeMessages)
+        }
+        _ => None,
+    }
 }
 
 struct ClaudePreparedRequest {
@@ -390,6 +450,110 @@ impl ClaudePreparedRequest {
                     Option::<&Vec<String>>::None,
                 )?,
             }),
+            _ => Err(UpstreamError::UnsupportedRequest),
+        }
+    }
+
+    fn from_payload(
+        operation: OperationFamily,
+        protocol: ProtocolKind,
+        body: &[u8],
+        cache_breakpoints: &[CacheBreakpointRule],
+    ) -> Result<Self, UpstreamError> {
+        fn json_pointer_string(value: &Value, pointer: &str) -> Option<String> {
+            value
+                .pointer(pointer)
+                .and_then(Value::as_str)
+                .map(ToOwned::to_owned)
+        }
+
+        fn parse_claude_payload_wrapper(
+            payload: &[u8],
+        ) -> Result<(Value, String, Option<Vec<String>>), UpstreamError> {
+            let value = serde_json::from_slice::<Value>(payload)
+                .map_err(|err| UpstreamError::SerializeRequest(err.to_string()))?;
+            if let Some(body_value) = value.get("body").cloned() {
+                let version = value
+                    .pointer("/headers/anthropic_version")
+                    .and_then(Value::as_str)
+                    .unwrap_or(ANTHROPIC_DEFAULT_VERSION)
+                    .to_string();
+                let beta = value
+                    .pointer("/headers/anthropic_beta")
+                    .and_then(Value::as_array)
+                    .map(|items| {
+                        items
+                            .iter()
+                            .filter_map(Value::as_str)
+                            .map(ToOwned::to_owned)
+                            .collect::<Vec<_>>()
+                    })
+                    .filter(|items| !items.is_empty());
+                return Ok((body_value, version, beta));
+            }
+            Ok((value, ANTHROPIC_DEFAULT_VERSION.to_string(), None))
+        }
+
+        match (operation, protocol) {
+            (OperationFamily::CountToken, ProtocolKind::Claude) => {
+                let (body_json, version, beta) = parse_claude_payload_wrapper(body)?;
+                Ok(Self {
+                    method: WreqMethod::POST,
+                    path: append_query_param_if_missing(
+                        "/v1/messages/count_tokens",
+                        BETA_QUERY_KEY,
+                        BETA_QUERY_VALUE,
+                    ),
+                    model: json_pointer_string(&body_json, "/model"),
+                    body: Some(
+                        serde_json::to_vec(&body_json)
+                            .map_err(|err| UpstreamError::SerializeRequest(err.to_string()))?,
+                    ),
+                    request_headers: anthropic_header_pairs(&version, beta.as_ref())?,
+                })
+            }
+            (OperationFamily::GenerateContent, ProtocolKind::Claude)
+            | (OperationFamily::StreamGenerateContent, ProtocolKind::Claude) => {
+                let (mut body_json, version, beta) = parse_claude_payload_wrapper(body)?;
+                apply_magic_string_cache_control_triggers(&mut body_json);
+                if !cache_breakpoints.is_empty() {
+                    ensure_cache_breakpoint_rules(&mut body_json, cache_breakpoints);
+                }
+                Ok(Self {
+                    method: WreqMethod::POST,
+                    path: append_query_param_if_missing(
+                        "/v1/messages",
+                        BETA_QUERY_KEY,
+                        BETA_QUERY_VALUE,
+                    ),
+                    model: json_pointer_string(&body_json, "/model"),
+                    body: Some(
+                        serde_json::to_vec(&body_json)
+                            .map_err(|err| UpstreamError::SerializeRequest(err.to_string()))?,
+                    ),
+                    request_headers: anthropic_header_pairs(&version, beta.as_ref())?,
+                })
+            }
+            (OperationFamily::GenerateContent, ProtocolKind::OpenAiChatCompletion)
+            | (OperationFamily::StreamGenerateContent, ProtocolKind::OpenAiChatCompletion) => {
+                let model = serde_json::from_slice::<Value>(body)
+                    .ok()
+                    .and_then(|value| json_pointer_string(&value, "/model"));
+                Ok(Self {
+                    method: WreqMethod::POST,
+                    path: append_query_param_if_missing(
+                        "/v1/chat/completions",
+                        BETA_QUERY_KEY,
+                        BETA_QUERY_VALUE,
+                    ),
+                    body: Some(body.to_vec()),
+                    model,
+                    request_headers: anthropic_header_pairs(
+                        &ANTHROPIC_DEFAULT_VERSION,
+                        Option::<&Vec<String>>::None,
+                    )?,
+                })
+            }
             _ => Err(UpstreamError::UnsupportedRequest),
         }
     }

--- a/crates/gproxy-provider/src/channels/claudecode/mod.rs
+++ b/crates/gproxy-provider/src/channels/claudecode/mod.rs
@@ -10,4 +10,7 @@ pub use credential::ClaudeCodeCredential;
 pub use dispatch::default_dispatch_table;
 pub use oauth::{execute_claudecode_oauth_callback, execute_claudecode_oauth_start};
 pub use settings::ClaudeCodeSettings;
-pub use upstream::{execute_claudecode_upstream_usage_with_retry, execute_claudecode_with_retry};
+pub use upstream::{
+    execute_claudecode_payload_with_retry, execute_claudecode_upstream_usage_with_retry,
+    execute_claudecode_with_retry,
+};

--- a/crates/gproxy-provider/src/channels/claudecode/upstream.rs
+++ b/crates/gproxy-provider/src/channels/claudecode/upstream.rs
@@ -1,4 +1,4 @@
-use gproxy_middleware::TransformResponse;
+use gproxy_middleware::{OperationFamily, ProtocolKind, TransformResponse};
 use serde_json::{Value, json};
 use wreq::{Client as WreqClient, Method as WreqMethod};
 
@@ -28,7 +28,7 @@ use crate::channels::utils::{
 use crate::channels::{BuiltinChannelCredential, ChannelCredential};
 use crate::credential::ChannelCredentialStateStore;
 use crate::credential_state::CredentialStateManager;
-use crate::provider::ProviderDefinition;
+use crate::provider::{ProviderDefinition, RetryWithPayloadRequest};
 
 const BETA_QUERY_KEY: &str = "beta";
 const BETA_QUERY_VALUE: &str = "true";
@@ -51,6 +51,71 @@ pub async fn execute_claudecode_with_retry(
         prelude_text,
         provider.settings.cache_breakpoints(),
     )?;
+    let cache_affinity_hint = if configured_pick_mode_uses_cache(provider.credential_pick_mode) {
+        crate::channels::retry::cache_affinity_protocol_from_transform_request(request).and_then(
+            |protocol| {
+                cache_affinity_hint_from_transform_request(
+                    protocol,
+                    prepared.model.as_deref(),
+                    prepared.body.as_deref(),
+                )
+            },
+        )
+    } else {
+        None
+    };
+    execute_claudecode_with_prepared(
+        client,
+        spoof_client,
+        provider,
+        credential_states,
+        prepared,
+        now_unix_ms,
+        cache_affinity_hint,
+    )
+    .await
+}
+
+pub async fn execute_claudecode_payload_with_retry(
+    client: &WreqClient,
+    spoof_client: &WreqClient,
+    provider: &ProviderDefinition,
+    credential_states: &ChannelCredentialStateStore,
+    payload: RetryWithPayloadRequest<'_>,
+) -> Result<UpstreamResponse, UpstreamError> {
+    let prelude_text = provider
+        .settings
+        .claudecode_prelude_text()
+        .map(str::trim)
+        .filter(|value| !value.is_empty());
+    let prepared = ClaudeCodePreparedRequest::from_payload(
+        payload.operation,
+        payload.protocol,
+        payload.body,
+        prelude_text,
+        provider.settings.cache_breakpoints(),
+    )?;
+    execute_claudecode_with_prepared(
+        client,
+        spoof_client,
+        provider,
+        credential_states,
+        prepared,
+        payload.now_unix_ms,
+        None,
+    )
+    .await
+}
+
+async fn execute_claudecode_with_prepared(
+    client: &WreqClient,
+    spoof_client: &WreqClient,
+    provider: &ProviderDefinition,
+    credential_states: &ChannelCredentialStateStore,
+    prepared: ClaudeCodePreparedRequest,
+    now_unix_ms: u64,
+    cache_affinity_hint: Option<crate::channels::retry::CacheAffinityHint>,
+) -> Result<UpstreamResponse, UpstreamError> {
     let base_url = provider.settings.base_url().trim();
     if base_url.is_empty() {
         return Err(UpstreamError::InvalidBaseUrl);
@@ -79,19 +144,6 @@ pub async fn execute_claudecode_with_retry(
         .map(str::trim)
         .map(ToOwned::to_owned)
         .unwrap_or_else(|| CLAUDE_CODE_UA.to_string());
-    let cache_affinity_hint = if configured_pick_mode_uses_cache(provider.credential_pick_mode) {
-        crate::channels::retry::cache_affinity_protocol_from_transform_request(request).and_then(
-            |protocol| {
-                cache_affinity_hint_from_transform_request(
-                    protocol,
-                    prepared.model.as_deref(),
-                    prepared.body.as_deref(),
-                )
-            },
-        )
-    } else {
-        None
-    };
     let pick_mode =
         credential_pick_mode(provider.credential_pick_mode, cache_affinity_hint.as_ref());
 
@@ -1069,6 +1121,193 @@ impl ClaudeCodePreparedRequest {
 
                 Ok(Self {
                     method: to_wreq_method(&value.method)?,
+                    path: append_query_param_if_missing(
+                        "/v1/messages",
+                        BETA_QUERY_KEY,
+                        BETA_QUERY_VALUE,
+                    ),
+                    body: Some(
+                        serde_json::to_vec(&body_json)
+                            .map_err(|err| UpstreamError::SerializeRequest(err.to_string()))?,
+                    ),
+                    model: Some(model),
+                    request_headers,
+                    context_1m_target,
+                })
+            }
+            _ => Err(UpstreamError::UnsupportedRequest),
+        }
+    }
+
+    fn from_payload(
+        operation: OperationFamily,
+        protocol: ProtocolKind,
+        body: &[u8],
+        prelude_text: Option<&str>,
+        cache_breakpoints: &[CacheBreakpointRule],
+    ) -> Result<Self, UpstreamError> {
+        fn json_pointer_string(value: &Value, pointer: &str) -> Option<String> {
+            value
+                .pointer(pointer)
+                .and_then(Value::as_str)
+                .map(ToOwned::to_owned)
+        }
+
+        fn parse_claude_payload_wrapper(
+            payload: &[u8],
+        ) -> Result<(Value, String, Option<Vec<String>>), UpstreamError> {
+            const DEFAULT_ANTHROPIC_VERSION: &str = "2023-06-01";
+
+            let value = serde_json::from_slice::<Value>(payload)
+                .map_err(|err| UpstreamError::SerializeRequest(err.to_string()))?;
+            if let Some(body_value) = value.get("body").cloned() {
+                let version = value
+                    .pointer("/headers/anthropic_version")
+                    .and_then(Value::as_str)
+                    .unwrap_or(DEFAULT_ANTHROPIC_VERSION)
+                    .to_string();
+                let beta = value
+                    .pointer("/headers/anthropic_beta")
+                    .and_then(Value::as_array)
+                    .map(|items| {
+                        items
+                            .iter()
+                            .filter_map(Value::as_str)
+                            .map(ToOwned::to_owned)
+                            .collect::<Vec<_>>()
+                    })
+                    .filter(|items| !items.is_empty());
+                return Ok((body_value, version, beta));
+            }
+            Ok((value, DEFAULT_ANTHROPIC_VERSION.to_string(), None))
+        }
+
+        match (operation, protocol) {
+            (OperationFamily::ModelList, ProtocolKind::Claude) => {
+                let payload = serde_json::from_slice::<Value>(body)
+                    .map_err(|err| UpstreamError::SerializeRequest(err.to_string()))?;
+                let version = payload
+                    .pointer("/headers/anthropic_version")
+                    .and_then(Value::as_str)
+                    .unwrap_or("2023-06-01")
+                    .to_string();
+                let beta = payload
+                    .pointer("/headers/anthropic_beta")
+                    .and_then(Value::as_array)
+                    .map(|items| {
+                        items
+                            .iter()
+                            .filter_map(Value::as_str)
+                            .map(ToOwned::to_owned)
+                            .collect::<Vec<_>>()
+                    });
+                let mut request_headers = anthropic_header_pairs(&version, beta.as_ref())?;
+                ensure_oauth_beta(&mut request_headers, false);
+                let path =
+                    append_query_param_if_missing("/v1/models", BETA_QUERY_KEY, BETA_QUERY_VALUE);
+                Ok(Self {
+                    method: WreqMethod::GET,
+                    path,
+                    body: None,
+                    model: None,
+                    request_headers,
+                    context_1m_target: None,
+                })
+            }
+            (OperationFamily::ModelGet, ProtocolKind::Claude) => {
+                let payload = serde_json::from_slice::<Value>(body)
+                    .map_err(|err| UpstreamError::SerializeRequest(err.to_string()))?;
+                let Some(model_id) = payload
+                    .pointer("/path/model_id")
+                    .and_then(Value::as_str)
+                    .map(str::trim)
+                    .filter(|value| !value.is_empty())
+                    .map(ToOwned::to_owned)
+                else {
+                    return Err(UpstreamError::SerializeRequest(
+                        "missing path.model_id in claudecode model_get payload".to_string(),
+                    ));
+                };
+                let version = payload
+                    .pointer("/headers/anthropic_version")
+                    .and_then(Value::as_str)
+                    .unwrap_or("2023-06-01")
+                    .to_string();
+                let beta = payload
+                    .pointer("/headers/anthropic_beta")
+                    .and_then(Value::as_array)
+                    .map(|items| {
+                        items
+                            .iter()
+                            .filter_map(Value::as_str)
+                            .map(ToOwned::to_owned)
+                            .collect::<Vec<_>>()
+                    });
+                let mut request_headers = anthropic_header_pairs(&version, beta.as_ref())?;
+                ensure_oauth_beta(&mut request_headers, false);
+                Ok(Self {
+                    method: WreqMethod::GET,
+                    path: append_query_param_if_missing(
+                        format!("/v1/models/{model_id}").as_str(),
+                        BETA_QUERY_KEY,
+                        BETA_QUERY_VALUE,
+                    ),
+                    body: None,
+                    model: Some(model_id),
+                    request_headers,
+                    context_1m_target: None,
+                })
+            }
+            (OperationFamily::CountToken, ProtocolKind::Claude) => {
+                let (mut body_json, version, beta) = parse_claude_payload_wrapper(body)?;
+                if let Some(prelude) = prelude_text {
+                    apply_claudecode_system(&mut body_json, prelude);
+                }
+                let model = json_pointer_string(&body_json, "/model").ok_or_else(|| {
+                    UpstreamError::SerializeRequest(
+                        "missing model in claudecode count_tokens payload".to_string(),
+                    )
+                })?;
+                let context_1m_target = claude_1m_target_for_model(model.as_str());
+                let mut request_headers = anthropic_header_pairs(&version, beta.as_ref())?;
+                ensure_oauth_beta(&mut request_headers, context_1m_target.is_some());
+                Ok(Self {
+                    method: WreqMethod::POST,
+                    path: append_query_param_if_missing(
+                        "/v1/messages/count_tokens",
+                        BETA_QUERY_KEY,
+                        BETA_QUERY_VALUE,
+                    ),
+                    body: Some(
+                        serde_json::to_vec(&body_json)
+                            .map_err(|err| UpstreamError::SerializeRequest(err.to_string()))?,
+                    ),
+                    model: Some(model),
+                    request_headers,
+                    context_1m_target,
+                })
+            }
+            (OperationFamily::GenerateContent, ProtocolKind::Claude)
+            | (OperationFamily::StreamGenerateContent, ProtocolKind::Claude) => {
+                let (mut body_json, version, beta) = parse_claude_payload_wrapper(body)?;
+                if let Some(prelude) = prelude_text {
+                    apply_claudecode_system(&mut body_json, prelude);
+                }
+                let model = json_pointer_string(&body_json, "/model").ok_or_else(|| {
+                    UpstreamError::SerializeRequest(
+                        "missing model in claudecode message payload".to_string(),
+                    )
+                })?;
+                normalize_claudecode_sampling(model.as_str(), &mut body_json);
+                apply_magic_string_cache_control_triggers(&mut body_json);
+                if !cache_breakpoints.is_empty() {
+                    ensure_cache_breakpoint_rules(&mut body_json, cache_breakpoints);
+                }
+                let context_1m_target = claude_1m_target_for_model(model.as_str());
+                let mut request_headers = anthropic_header_pairs(&version, beta.as_ref())?;
+                ensure_oauth_beta(&mut request_headers, context_1m_target.is_some());
+                Ok(Self {
+                    method: WreqMethod::POST,
                     path: append_query_param_if_missing(
                         "/v1/messages",
                         BETA_QUERY_KEY,

--- a/crates/gproxy-provider/src/channels/codex/mod.rs
+++ b/crates/gproxy-provider/src/channels/codex/mod.rs
@@ -9,4 +9,7 @@ pub use credential::CodexCredential;
 pub use dispatch::default_dispatch_table;
 pub use oauth::{execute_codex_oauth_callback, execute_codex_oauth_start};
 pub use settings::CodexSettings;
-pub use upstream::{execute_codex_upstream_usage_with_retry, execute_codex_with_retry};
+pub use upstream::{
+    execute_codex_payload_with_retry, execute_codex_upstream_usage_with_retry,
+    execute_codex_with_retry,
+};

--- a/crates/gproxy-provider/src/channels/codex/upstream.rs
+++ b/crates/gproxy-provider/src/channels/codex/upstream.rs
@@ -1,6 +1,6 @@
 use std::time::{SystemTime, UNIX_EPOCH};
 
-use gproxy_middleware::{TransformRequest, TransformResponse};
+use gproxy_middleware::{OperationFamily, ProtocolKind, TransformRequest, TransformResponse};
 use serde_json::{Value, json};
 use wreq::{Client as WreqClient, Method as WreqMethod};
 
@@ -26,7 +26,7 @@ use crate::channels::utils::{
 use crate::channels::{BuiltinChannelCredential, ChannelCredential};
 use crate::credential::ChannelCredentialStateStore;
 use crate::credential_state::CredentialStateManager;
-use crate::provider::{ProviderDefinition, TokenizerResolutionContext};
+use crate::provider::{ProviderDefinition, RetryWithPayloadRequest, TokenizerResolutionContext};
 
 #[derive(Debug, Clone)]
 enum CodexRequestKind {
@@ -59,6 +59,89 @@ pub async fn execute_codex_with_retry(
     }
 
     let prepared = CodexPreparedRequest::from_transform_request(request)?;
+    let cache_affinity_hint = if configured_pick_mode_uses_cache(provider.credential_pick_mode) {
+        crate::channels::retry::cache_affinity_protocol_from_transform_request(request).and_then(
+            |protocol| {
+                cache_affinity_hint_from_transform_request(
+                    protocol,
+                    prepared.model.as_deref(),
+                    prepared.body.as_deref(),
+                )
+            },
+        )
+    } else {
+        None
+    };
+    execute_codex_with_prepared(
+        client,
+        provider,
+        credential_states,
+        prepared,
+        now_unix_ms,
+        cache_affinity_hint,
+    )
+    .await
+}
+
+pub async fn execute_codex_payload_with_retry(
+    client: &WreqClient,
+    provider: &ProviderDefinition,
+    credential_states: &ChannelCredentialStateStore,
+    payload: RetryWithPayloadRequest<'_>,
+) -> Result<UpstreamResponse, UpstreamError> {
+    if (payload.operation, payload.protocol) == (OperationFamily::CountToken, ProtocolKind::OpenAi)
+    {
+        let body_json = serde_json::from_slice::<Value>(payload.body)
+            .map_err(|err| UpstreamError::SerializeRequest(err.to_string()))?;
+        let model = body_json
+            .get("model")
+            .and_then(Value::as_str)
+            .map(ToOwned::to_owned);
+        let input_tokens = count_openai_input_tokens_with_resolution(
+            payload.token_resolution.tokenizer_store,
+            client,
+            payload.token_resolution.hf_token,
+            payload.token_resolution.hf_url,
+            model.as_deref(),
+            &body_json,
+        )
+        .await?;
+        let response_json = json!({
+            "stats_code": 200,
+            "headers": {},
+            "body": {
+                "input_tokens": input_tokens,
+                "object": "response.input_tokens",
+            }
+        });
+        let response = serde_json::from_value(response_json)
+            .map_err(|err| UpstreamError::SerializeRequest(err.to_string()))?;
+        return Ok(UpstreamResponse::from_local(
+            TransformResponse::CountTokenOpenAi(response),
+        ));
+    }
+
+    let prepared =
+        CodexPreparedRequest::from_payload(payload.operation, payload.protocol, payload.body)?;
+    execute_codex_with_prepared(
+        client,
+        provider,
+        credential_states,
+        prepared,
+        payload.now_unix_ms,
+        None,
+    )
+    .await
+}
+
+async fn execute_codex_with_prepared(
+    client: &WreqClient,
+    provider: &ProviderDefinition,
+    credential_states: &ChannelCredentialStateStore,
+    prepared: CodexPreparedRequest,
+    now_unix_ms: u64,
+    cache_affinity_hint: Option<crate::channels::retry::CacheAffinityHint>,
+) -> Result<UpstreamResponse, UpstreamError> {
     let base_url = provider.settings.base_url().trim();
     if base_url.is_empty() {
         return Err(UpstreamError::InvalidBaseUrl);
@@ -73,19 +156,6 @@ pub async fn execute_codex_with_retry(
     let base_url_template = base_url.to_string();
     let user_agent_template =
         resolve_user_agent_or_default(provider.settings.user_agent(), USER_AGENT_VALUE);
-    let cache_affinity_hint = if configured_pick_mode_uses_cache(provider.credential_pick_mode) {
-        crate::channels::retry::cache_affinity_protocol_from_transform_request(request).and_then(
-            |protocol| {
-                cache_affinity_hint_from_transform_request(
-                    protocol,
-                    prepared.model.as_deref(),
-                    prepared.body.as_deref(),
-                )
-            },
-        )
-    } else {
-        None
-    };
     let pick_mode =
         credential_pick_mode(provider.credential_pick_mode, cache_affinity_hint.as_ref());
 
@@ -793,6 +863,91 @@ impl CodexPreparedRequest {
                             .map_err(|err| UpstreamError::SerializeRequest(err.to_string()))?,
                     ),
                     model: Some(normalize_model_id(value.body.model.as_str())),
+                    kind: CodexRequestKind::Forward,
+                })
+            }
+            _ => Err(UpstreamError::UnsupportedRequest),
+        }
+    }
+
+    fn from_payload(
+        operation: OperationFamily,
+        protocol: ProtocolKind,
+        body: &[u8],
+    ) -> Result<Self, UpstreamError> {
+        fn json_pointer_string(body: &[u8], pointer: &str) -> Option<String> {
+            serde_json::from_slice::<Value>(body)
+                .ok()
+                .and_then(|value| {
+                    value
+                        .pointer(pointer)
+                        .and_then(Value::as_str)
+                        .map(ToOwned::to_owned)
+                })
+        }
+
+        match (operation, protocol) {
+            (OperationFamily::ModelList, ProtocolKind::OpenAi) => Ok(Self {
+                method: WreqMethod::GET,
+                path: codex_models_path(),
+                body: None,
+                model: None,
+                kind: CodexRequestKind::ModelList,
+            }),
+            (OperationFamily::ModelGet, ProtocolKind::OpenAi) => {
+                let Some(target_raw) = json_pointer_string(body, "/path/model") else {
+                    return Err(UpstreamError::SerializeRequest(
+                        "missing path.model in codex model_get payload".to_string(),
+                    ));
+                };
+                let target = normalize_model_id(target_raw.as_str());
+                Ok(Self {
+                    method: WreqMethod::GET,
+                    path: codex_models_path(),
+                    body: None,
+                    model: Some(target.clone()),
+                    kind: CodexRequestKind::ModelGet { target },
+                })
+            }
+            (OperationFamily::GenerateContent, ProtocolKind::OpenAi)
+            | (OperationFamily::StreamGenerateContent, ProtocolKind::OpenAi) => {
+                let mut body_json = serde_json::from_slice::<Value>(body)
+                    .map_err(|err| UpstreamError::SerializeRequest(err.to_string()))?;
+                normalize_codex_response_request_body(
+                    &mut body_json,
+                    operation == OperationFamily::StreamGenerateContent,
+                );
+                let model = body_json
+                    .get("model")
+                    .and_then(Value::as_str)
+                    .map(normalize_model_id);
+                Ok(Self {
+                    method: WreqMethod::POST,
+                    path: "/responses".to_string(),
+                    body: Some(
+                        serde_json::to_vec(&body_json)
+                            .map_err(|err| UpstreamError::SerializeRequest(err.to_string()))?,
+                    ),
+                    model,
+                    kind: CodexRequestKind::Forward,
+                })
+            }
+            (OperationFamily::Compact, ProtocolKind::OpenAi) => {
+                let mut body_json = serde_json::from_slice::<Value>(body)
+                    .map_err(|err| UpstreamError::SerializeRequest(err.to_string()))?;
+                normalize_codex_compact_request_body(&mut body_json);
+                let model = body_json
+                    .get("model")
+                    .and_then(Value::as_str)
+                    .map(normalize_model_id);
+                Ok(Self {
+                    method: WreqMethod::POST,
+                    path: "/responses/compact".to_string(),
+                    body: Some(
+                        serde_json::to_vec(&body_json)
+                            .map_err(|err| UpstreamError::SerializeRequest(err.to_string()))?,
+                    ),
+                    model,
                     kind: CodexRequestKind::Forward,
                 })
             }

--- a/crates/gproxy-provider/src/channels/deepseek/mod.rs
+++ b/crates/gproxy-provider/src/channels/deepseek/mod.rs
@@ -7,4 +7,7 @@ pub mod upstream;
 pub use credential::DeepseekCredential;
 pub use dispatch::default_dispatch_table;
 pub use settings::DeepseekSettings;
-pub use upstream::{execute_deepseek_with_retry, normalize_deepseek_upstream_response_body};
+pub use upstream::{
+    execute_deepseek_payload_with_retry, execute_deepseek_with_retry,
+    normalize_deepseek_upstream_response_body,
+};

--- a/crates/gproxy-provider/src/channels/deepseek/upstream.rs
+++ b/crates/gproxy-provider/src/channels/deepseek/upstream.rs
@@ -1,4 +1,4 @@
-use gproxy_middleware::{TransformRequest, TransformResponse};
+use gproxy_middleware::{OperationFamily, ProtocolKind, TransformRequest, TransformResponse};
 use serde_json::{Map, Value};
 use wreq::{Client as WreqClient, Method as WreqMethod};
 
@@ -16,7 +16,7 @@ use crate::channels::utils::{
 use crate::channels::{BuiltinChannelCredential, ChannelCredential};
 use crate::credential::ChannelCredentialStateStore;
 use crate::credential_state::CredentialStateManager;
-use crate::provider::{ProviderDefinition, TokenizerResolutionContext};
+use crate::provider::{ProviderDefinition, RetryWithPayloadRequest, TokenizerResolutionContext};
 
 const DEEPSEEK_UNSUPPORTED_CHAT_FIELDS: &[&str] = &[
     "audio",
@@ -89,6 +89,89 @@ pub async fn execute_deepseek_with_retry(
     }
 
     let prepared = DeepseekPreparedRequest::from_transform_request(request)?;
+    let cache_affinity_hint = if configured_pick_mode_uses_cache(provider.credential_pick_mode) {
+        crate::channels::retry::cache_affinity_protocol_from_transform_request(request).and_then(
+            |protocol| {
+                cache_affinity_hint_from_transform_request(
+                    protocol,
+                    prepared.model.as_deref(),
+                    prepared.body.as_deref(),
+                )
+            },
+        )
+    } else {
+        None
+    };
+    execute_deepseek_with_prepared(
+        client,
+        provider,
+        credential_states,
+        prepared,
+        now_unix_ms,
+        cache_affinity_hint,
+    )
+    .await
+}
+
+pub async fn execute_deepseek_payload_with_retry(
+    client: &WreqClient,
+    provider: &ProviderDefinition,
+    credential_states: &ChannelCredentialStateStore,
+    payload: RetryWithPayloadRequest<'_>,
+) -> Result<UpstreamResponse, UpstreamError> {
+    if (payload.operation, payload.protocol) == (OperationFamily::CountToken, ProtocolKind::OpenAi)
+    {
+        let body_json = serde_json::from_slice::<Value>(payload.body)
+            .map_err(|err| UpstreamError::SerializeRequest(err.to_string()))?;
+        let model = body_json
+            .get("model")
+            .and_then(Value::as_str)
+            .map(ToOwned::to_owned);
+        let input_tokens = count_openai_input_tokens_with_resolution(
+            payload.token_resolution.tokenizer_store,
+            client,
+            payload.token_resolution.hf_token,
+            payload.token_resolution.hf_url,
+            model.as_deref(),
+            &body_json,
+        )
+        .await?;
+        let response_json = serde_json::json!({
+            "stats_code": 200,
+            "headers": {},
+            "body": {
+                "input_tokens": input_tokens,
+                "object": "response.input_tokens",
+            }
+        });
+        let response = serde_json::from_value(response_json)
+            .map_err(|err| UpstreamError::SerializeRequest(err.to_string()))?;
+        return Ok(UpstreamResponse::from_local(
+            TransformResponse::CountTokenOpenAi(response),
+        ));
+    }
+
+    let prepared =
+        DeepseekPreparedRequest::from_payload(payload.operation, payload.protocol, payload.body)?;
+    execute_deepseek_with_prepared(
+        client,
+        provider,
+        credential_states,
+        prepared,
+        payload.now_unix_ms,
+        None,
+    )
+    .await
+}
+
+async fn execute_deepseek_with_prepared(
+    client: &WreqClient,
+    provider: &ProviderDefinition,
+    credential_states: &ChannelCredentialStateStore,
+    prepared: DeepseekPreparedRequest,
+    now_unix_ms: u64,
+    cache_affinity_hint: Option<crate::channels::retry::CacheAffinityHint>,
+) -> Result<UpstreamResponse, UpstreamError> {
     let base_url = provider.settings.base_url().trim();
     if base_url.is_empty() {
         return Err(UpstreamError::InvalidBaseUrl);
@@ -103,19 +186,6 @@ pub async fn execute_deepseek_with_retry(
     let request_headers_template = prepared.request_headers.clone();
     let user_agent_template =
         resolve_user_agent_or_else(provider.settings.user_agent(), default_gproxy_user_agent);
-    let cache_affinity_hint = if configured_pick_mode_uses_cache(provider.credential_pick_mode) {
-        crate::channels::retry::cache_affinity_protocol_from_transform_request(request).and_then(
-            |protocol| {
-                cache_affinity_hint_from_transform_request(
-                    protocol,
-                    prepared.model.as_deref(),
-                    prepared.body.as_deref(),
-                )
-            },
-        )
-    } else {
-        None
-    };
     let pick_mode =
         credential_pick_mode(provider.credential_pick_mode, cache_affinity_hint.as_ref());
 
@@ -406,6 +476,128 @@ impl DeepseekPreparedRequest {
                         &value.headers.anthropic_version,
                         value.headers.anthropic_beta.as_ref(),
                     )?,
+                })
+            }
+            _ => Err(UpstreamError::UnsupportedRequest),
+        }
+    }
+
+    fn from_payload(
+        operation: OperationFamily,
+        protocol: ProtocolKind,
+        body: &[u8],
+    ) -> Result<Self, UpstreamError> {
+        fn json_pointer_string(value: &Value, pointer: &str) -> Option<String> {
+            value
+                .pointer(pointer)
+                .and_then(Value::as_str)
+                .map(ToOwned::to_owned)
+        }
+
+        fn parse_claude_payload_wrapper(
+            payload: &[u8],
+        ) -> Result<(Value, String, Option<Vec<String>>), UpstreamError> {
+            const DEFAULT_ANTHROPIC_VERSION: &str = "2023-06-01";
+
+            let value = serde_json::from_slice::<Value>(payload)
+                .map_err(|err| UpstreamError::SerializeRequest(err.to_string()))?;
+            if let Some(body_value) = value.get("body").cloned() {
+                let version = value
+                    .pointer("/headers/anthropic_version")
+                    .and_then(Value::as_str)
+                    .unwrap_or(DEFAULT_ANTHROPIC_VERSION)
+                    .to_string();
+                let beta = value
+                    .pointer("/headers/anthropic_beta")
+                    .and_then(Value::as_array)
+                    .map(|items| {
+                        items
+                            .iter()
+                            .filter_map(Value::as_str)
+                            .map(ToOwned::to_owned)
+                            .collect::<Vec<_>>()
+                    })
+                    .filter(|items| !items.is_empty());
+                return Ok((body_value, version, beta));
+            }
+            Ok((value, DEFAULT_ANTHROPIC_VERSION.to_string(), None))
+        }
+
+        match (operation, protocol) {
+            (OperationFamily::ModelList, ProtocolKind::OpenAi) => Ok(Self {
+                method: WreqMethod::GET,
+                path: "/v1/models".to_string(),
+                body: None,
+                model: None,
+                auth_scheme: AuthScheme::Bearer,
+                request_headers: Vec::new(),
+            }),
+            (OperationFamily::ModelGet, ProtocolKind::OpenAi) => {
+                let value = serde_json::from_slice::<Value>(body)
+                    .map_err(|err| UpstreamError::SerializeRequest(err.to_string()))?;
+                let Some(model) = json_pointer_string(&value, "/path/model") else {
+                    return Err(UpstreamError::SerializeRequest(
+                        "missing path.model in deepseek model_get payload".to_string(),
+                    ));
+                };
+                Ok(Self {
+                    method: WreqMethod::GET,
+                    path: format!("/v1/models/{model}"),
+                    body: None,
+                    model: Some(model),
+                    auth_scheme: AuthScheme::Bearer,
+                    request_headers: Vec::new(),
+                })
+            }
+            (OperationFamily::GenerateContent, ProtocolKind::OpenAiChatCompletion)
+            | (OperationFamily::StreamGenerateContent, ProtocolKind::OpenAiChatCompletion) => {
+                let mut body_json = serde_json::from_slice::<Value>(body)
+                    .map_err(|err| UpstreamError::SerializeRequest(err.to_string()))?;
+                if let Some(map) = body_json.as_object_mut() {
+                    if let Some(max_tokens) = map.get("max_tokens").and_then(Value::as_u64) {
+                        map.insert("max_tokens".to_string(), Value::from(max_tokens.min(8192)));
+                    }
+                    if let Some(max_completion_tokens) =
+                        map.get("max_completion_tokens").and_then(Value::as_u64)
+                    {
+                        map.insert(
+                            "max_completion_tokens".to_string(),
+                            Value::from(max_completion_tokens.min(8192)),
+                        );
+                    }
+                }
+                normalize_deepseek_chat_request_body(&mut body_json);
+                Ok(Self {
+                    method: WreqMethod::POST,
+                    path: "/v1/chat/completions".to_string(),
+                    body: Some(
+                        serde_json::to_vec(&body_json)
+                            .map_err(|err| UpstreamError::SerializeRequest(err.to_string()))?,
+                    ),
+                    model: json_pointer_string(&body_json, "/model"),
+                    auth_scheme: AuthScheme::Bearer,
+                    request_headers: Vec::new(),
+                })
+            }
+            (OperationFamily::GenerateContent, ProtocolKind::Claude)
+            | (OperationFamily::StreamGenerateContent, ProtocolKind::Claude) => {
+                let (mut body_json, version, beta) = parse_claude_payload_wrapper(body)?;
+                let model = json_pointer_string(&body_json, "/model");
+                if let Some(model_value) = model.clone()
+                    && let Some(map) = body_json.as_object_mut()
+                {
+                    map.insert("model".to_string(), Value::String(model_value));
+                }
+                Ok(Self {
+                    method: WreqMethod::POST,
+                    path: "/anthropic/v1/messages".to_string(),
+                    body: Some(
+                        serde_json::to_vec(&body_json)
+                            .map_err(|err| UpstreamError::SerializeRequest(err.to_string()))?,
+                    ),
+                    model,
+                    auth_scheme: AuthScheme::XApiKey,
+                    request_headers: anthropic_header_pairs(&version, beta.as_ref())?,
                 })
             }
             _ => Err(UpstreamError::UnsupportedRequest),

--- a/crates/gproxy-provider/src/channels/geminicli/mod.rs
+++ b/crates/gproxy-provider/src/channels/geminicli/mod.rs
@@ -12,6 +12,7 @@ pub use oauth::{
 };
 pub use settings::GeminiCliSettings;
 pub use upstream::{
-    execute_geminicli_upstream_usage_with_retry, execute_geminicli_with_retry,
-    normalize_geminicli_upstream_response_body, normalize_geminicli_upstream_stream_ndjson_chunk,
+    execute_geminicli_payload_with_retry, execute_geminicli_upstream_usage_with_retry,
+    execute_geminicli_with_retry, normalize_geminicli_upstream_response_body,
+    normalize_geminicli_upstream_stream_ndjson_chunk,
 };

--- a/crates/gproxy-provider/src/channels/geminicli/upstream.rs
+++ b/crates/gproxy-provider/src/channels/geminicli/upstream.rs
@@ -1,4 +1,4 @@
-use gproxy_middleware::{TransformRequest, TransformResponse};
+use gproxy_middleware::{OperationFamily, ProtocolKind, TransformRequest, TransformResponse};
 use serde_json::{Map, Value, json};
 use wreq::{Client as WreqClient, Method as WreqMethod, Response as WreqResponse};
 
@@ -23,6 +23,8 @@ use crate::channels::{BuiltinChannelCredential, ChannelCredential};
 use crate::credential::ChannelCredentialStateStore;
 use crate::credential_state::CredentialStateManager;
 use crate::provider::ProviderDefinition;
+
+type ParsedGeminiPayload = (Option<String>, Option<Value>, Option<String>);
 
 #[derive(Debug, Clone)]
 enum GeminiCliRequestKind {
@@ -56,6 +58,63 @@ pub async fn execute_geminicli_with_retry(
     now_unix_ms: u64,
 ) -> Result<UpstreamResponse, UpstreamError> {
     let prepared = GeminiCliPreparedRequest::from_transform_request(request)?;
+    let affinity_body_template = prepared
+        .body
+        .as_ref()
+        .and_then(|body| serde_json::to_vec(body).ok());
+    let cache_affinity_hint = if configured_pick_mode_uses_cache(provider.credential_pick_mode) {
+        crate::channels::retry::cache_affinity_protocol_from_transform_request(request).and_then(
+            |protocol| {
+                cache_affinity_hint_from_transform_request(
+                    protocol,
+                    prepared.model.as_deref(),
+                    affinity_body_template.as_deref(),
+                )
+            },
+        )
+    } else {
+        None
+    };
+    execute_geminicli_with_prepared(
+        client,
+        provider,
+        credential_states,
+        prepared,
+        now_unix_ms,
+        cache_affinity_hint,
+    )
+    .await
+}
+
+pub async fn execute_geminicli_payload_with_retry(
+    client: &WreqClient,
+    provider: &ProviderDefinition,
+    credential_states: &ChannelCredentialStateStore,
+    operation: OperationFamily,
+    protocol: ProtocolKind,
+    body: &[u8],
+    now_unix_ms: u64,
+) -> Result<UpstreamResponse, UpstreamError> {
+    let prepared = GeminiCliPreparedRequest::from_payload(operation, protocol, body)?;
+    execute_geminicli_with_prepared(
+        client,
+        provider,
+        credential_states,
+        prepared,
+        now_unix_ms,
+        None,
+    )
+    .await
+}
+
+async fn execute_geminicli_with_prepared(
+    client: &WreqClient,
+    provider: &ProviderDefinition,
+    credential_states: &ChannelCredentialStateStore,
+    prepared: GeminiCliPreparedRequest,
+    now_unix_ms: u64,
+    cache_affinity_hint: Option<crate::channels::retry::CacheAffinityHint>,
+) -> Result<UpstreamResponse, UpstreamError> {
     if let Some(upstream_response) =
         try_usage_model_response(client, provider, credential_states, &prepared, now_unix_ms)
             .await?
@@ -81,23 +140,6 @@ pub async fn execute_geminicli_with_retry(
         .user_agent()
         .map(str::trim)
         .map(ToOwned::to_owned);
-    let affinity_body_template = prepared
-        .body
-        .as_ref()
-        .and_then(|body| serde_json::to_vec(body).ok());
-    let cache_affinity_hint = if configured_pick_mode_uses_cache(provider.credential_pick_mode) {
-        crate::channels::retry::cache_affinity_protocol_from_transform_request(request).and_then(
-            |protocol| {
-                cache_affinity_hint_from_transform_request(
-                    protocol,
-                    prepared.model.as_deref(),
-                    affinity_body_template.as_deref(),
-                )
-            },
-        )
-    } else {
-        None
-    };
     let pick_mode =
         credential_pick_mode(provider.credential_pick_mode, cache_affinity_hint.as_ref());
 
@@ -883,6 +925,179 @@ impl GeminiCliPreparedRequest {
                             .map_err(|err| UpstreamError::SerializeRequest(err.to_string()))?,
                     ),
                     model: Some(normalize_model_id(value.path.model.as_str())),
+                    kind: GeminiCliRequestKind::Forward {
+                        requires_project: false,
+                    },
+                })
+            }
+            _ => Err(UpstreamError::UnsupportedRequest),
+        }
+    }
+
+    fn from_payload(
+        operation: OperationFamily,
+        protocol: ProtocolKind,
+        body: &[u8],
+    ) -> Result<Self, UpstreamError> {
+        fn parse_gemini_payload_wrapper(
+            payload: &[u8],
+        ) -> Result<ParsedGeminiPayload, UpstreamError> {
+            let value = serde_json::from_slice::<Value>(payload)
+                .map_err(|err| UpstreamError::SerializeRequest(err.to_string()))?;
+            let model = value
+                .pointer("/path/model")
+                .or_else(|| value.pointer("/path/name"))
+                .and_then(Value::as_str)
+                .map(ToOwned::to_owned);
+            let body_value = value.get("body").cloned();
+            let alt = value
+                .pointer("/query/alt")
+                .and_then(Value::as_str)
+                .map(ToOwned::to_owned);
+            Ok((model, body_value, alt))
+        }
+
+        match (operation, protocol) {
+            (OperationFamily::ModelList, ProtocolKind::Gemini) => {
+                let payload = serde_json::from_slice::<Value>(body)
+                    .map_err(|err| UpstreamError::SerializeRequest(err.to_string()))?;
+                let page_size = payload
+                    .pointer("/query/page_size")
+                    .and_then(Value::as_u64)
+                    .map(|value| value as u32);
+                let page_token = payload
+                    .pointer("/query/page_token")
+                    .and_then(Value::as_str)
+                    .map(ToOwned::to_owned);
+                Ok(Self {
+                    method: WreqMethod::GET,
+                    path: String::new(),
+                    query: None,
+                    body: None,
+                    model: None,
+                    kind: GeminiCliRequestKind::LocalModelList {
+                        page_size,
+                        page_token,
+                    },
+                })
+            }
+            (OperationFamily::ModelGet, ProtocolKind::Gemini) => {
+                let payload = serde_json::from_slice::<Value>(body)
+                    .map_err(|err| UpstreamError::SerializeRequest(err.to_string()))?;
+                let Some(target) = payload
+                    .pointer("/path/name")
+                    .or_else(|| payload.pointer("/path/model"))
+                    .and_then(Value::as_str)
+                    .map(ToOwned::to_owned)
+                else {
+                    return Err(UpstreamError::SerializeRequest(
+                        "missing path.name in geminicli model_get payload".to_string(),
+                    ));
+                };
+                Ok(Self {
+                    method: WreqMethod::GET,
+                    path: String::new(),
+                    query: None,
+                    body: None,
+                    model: Some(normalize_model_id(target.as_str())),
+                    kind: GeminiCliRequestKind::LocalModelGet {
+                        target: normalize_model_name(target.as_str()),
+                    },
+                })
+            }
+            (OperationFamily::CountToken, ProtocolKind::Gemini) => {
+                let (model, body_value, _) = parse_gemini_payload_wrapper(body)?;
+                let Some(model) = model else {
+                    return Err(UpstreamError::SerializeRequest(
+                        "missing path.model in geminicli count_tokens payload".to_string(),
+                    ));
+                };
+                let Some(body_value) = body_value else {
+                    return Err(UpstreamError::SerializeRequest(
+                        "missing body in geminicli count_tokens payload".to_string(),
+                    ));
+                };
+                let model = normalize_model_id(model.as_str());
+                Ok(Self {
+                    method: WreqMethod::POST,
+                    path: "/v1internal:countTokens".to_string(),
+                    query: None,
+                    body: Some(geminicli_count_tokens_request(model.as_str(), &body_value)?),
+                    model: Some(model),
+                    kind: GeminiCliRequestKind::Forward {
+                        requires_project: false,
+                    },
+                })
+            }
+            (OperationFamily::GenerateContent, ProtocolKind::Gemini) => {
+                let (model, body_value, _) = parse_gemini_payload_wrapper(body)?;
+                let Some(model) = model else {
+                    return Err(UpstreamError::SerializeRequest(
+                        "missing path.model in geminicli generate payload".to_string(),
+                    ));
+                };
+                let Some(mut body_value) = body_value else {
+                    return Err(UpstreamError::SerializeRequest(
+                        "missing body in geminicli generate payload".to_string(),
+                    ));
+                };
+                strip_geminicli_unsupported_generation_config(&mut body_value);
+                Ok(Self {
+                    method: WreqMethod::POST,
+                    path: "/v1internal:generateContent".to_string(),
+                    query: None,
+                    body: Some(body_value),
+                    model: Some(normalize_model_id(model.as_str())),
+                    kind: GeminiCliRequestKind::Forward {
+                        requires_project: true,
+                    },
+                })
+            }
+            (OperationFamily::StreamGenerateContent, ProtocolKind::Gemini)
+            | (OperationFamily::StreamGenerateContent, ProtocolKind::GeminiNDJson) => {
+                let (model, body_value, alt) = parse_gemini_payload_wrapper(body)?;
+                let Some(model) = model else {
+                    return Err(UpstreamError::SerializeRequest(
+                        "missing path.model in geminicli stream payload".to_string(),
+                    ));
+                };
+                let Some(mut body_value) = body_value else {
+                    return Err(UpstreamError::SerializeRequest(
+                        "missing body in geminicli stream payload".to_string(),
+                    ));
+                };
+                strip_geminicli_unsupported_generation_config(&mut body_value);
+                let query = Some(format!("alt={}", alt.unwrap_or_else(|| "sse".to_string())));
+                Ok(Self {
+                    method: WreqMethod::POST,
+                    path: "/v1internal:streamGenerateContent".to_string(),
+                    query,
+                    body: Some(body_value),
+                    model: Some(normalize_model_id(model.as_str())),
+                    kind: GeminiCliRequestKind::Forward {
+                        requires_project: true,
+                    },
+                })
+            }
+            (OperationFamily::Embedding, ProtocolKind::Gemini) => {
+                let (model, body_value, _) = parse_gemini_payload_wrapper(body)?;
+                let Some(model) = model else {
+                    return Err(UpstreamError::SerializeRequest(
+                        "missing path.model in geminicli embedding payload".to_string(),
+                    ));
+                };
+                let Some(body_value) = body_value else {
+                    return Err(UpstreamError::SerializeRequest(
+                        "missing body in geminicli embedding payload".to_string(),
+                    ));
+                };
+                let model_name = normalize_model_name(model.as_str());
+                Ok(Self {
+                    method: WreqMethod::POST,
+                    path: format!("/v1beta/{model_name}:embedContent"),
+                    query: None,
+                    body: Some(body_value),
+                    model: Some(normalize_model_id(model.as_str())),
                     kind: GeminiCliRequestKind::Forward {
                         requires_project: false,
                     },

--- a/crates/gproxy-provider/src/channels/groq/mod.rs
+++ b/crates/gproxy-provider/src/channels/groq/mod.rs
@@ -7,4 +7,4 @@ pub mod upstream;
 pub use credential::GroqCredential;
 pub use dispatch::default_dispatch_table;
 pub use settings::GroqSettings;
-pub use upstream::execute_groq_with_retry;
+pub use upstream::{execute_groq_payload_with_retry, execute_groq_with_retry};

--- a/crates/gproxy-provider/src/channels/groq/upstream.rs
+++ b/crates/gproxy-provider/src/channels/groq/upstream.rs
@@ -1,4 +1,4 @@
-use gproxy_middleware::{TransformRequest, TransformResponse};
+use gproxy_middleware::{OperationFamily, ProtocolKind, TransformRequest, TransformResponse};
 use serde_json::{Map, Number, Value};
 use wreq::{Client as WreqClient, Method as WreqMethod};
 
@@ -16,7 +16,7 @@ use crate::channels::utils::{
 use crate::channels::{BuiltinChannelCredential, ChannelCredential};
 use crate::credential::ChannelCredentialStateStore;
 use crate::credential_state::CredentialStateManager;
-use crate::provider::{ProviderDefinition, TokenizerResolutionContext};
+use crate::provider::{ProviderDefinition, RetryWithPayloadRequest, TokenizerResolutionContext};
 
 const GROQ_UNSUPPORTED_CHAT_FIELDS: &[&str] = &["logit_bias", "logprobs", "top_logprobs"];
 const GROQ_UNSUPPORTED_RESPONSES_FIELDS: &[&str] = &[
@@ -75,18 +75,6 @@ pub async fn execute_groq_with_retry(
     }
 
     let prepared = GroqPreparedRequest::from_transform_request(request)?;
-    let base_url = provider.settings.base_url().trim();
-    if base_url.is_empty() {
-        return Err(UpstreamError::InvalidBaseUrl);
-    }
-    let url = join_base_url_and_path(base_url, &prepared.path);
-    let state_manager = CredentialStateManager::new(now_unix_ms);
-    let method_template = prepared.method.clone();
-    let body_template = prepared.body.clone();
-    let model_template = prepared.model.clone();
-    let url_template = url.clone();
-    let user_agent_template =
-        resolve_user_agent_or_else(provider.settings.user_agent(), default_gproxy_user_agent);
     let cache_affinity_hint = if configured_pick_mode_uses_cache(provider.credential_pick_mode) {
         crate::channels::retry::cache_affinity_protocol_from_transform_request(request).and_then(
             |protocol| {
@@ -100,6 +88,88 @@ pub async fn execute_groq_with_retry(
     } else {
         None
     };
+    execute_groq_with_prepared(
+        client,
+        provider,
+        credential_states,
+        prepared,
+        now_unix_ms,
+        cache_affinity_hint,
+    )
+    .await
+}
+
+pub async fn execute_groq_payload_with_retry(
+    client: &WreqClient,
+    provider: &ProviderDefinition,
+    credential_states: &ChannelCredentialStateStore,
+    payload: RetryWithPayloadRequest<'_>,
+) -> Result<UpstreamResponse, UpstreamError> {
+    if (payload.operation, payload.protocol) == (OperationFamily::CountToken, ProtocolKind::OpenAi)
+    {
+        let body_json = serde_json::from_slice::<Value>(payload.body)
+            .map_err(|err| UpstreamError::SerializeRequest(err.to_string()))?;
+        let model = body_json
+            .get("model")
+            .and_then(Value::as_str)
+            .map(ToOwned::to_owned);
+        let input_tokens = count_openai_input_tokens_with_resolution(
+            payload.token_resolution.tokenizer_store,
+            client,
+            payload.token_resolution.hf_token,
+            payload.token_resolution.hf_url,
+            model.as_deref(),
+            &body_json,
+        )
+        .await?;
+        let response_json = serde_json::json!({
+            "stats_code": 200,
+            "headers": {},
+            "body": {
+                "input_tokens": input_tokens,
+                "object": "response.input_tokens",
+            }
+        });
+        let response = serde_json::from_value(response_json)
+            .map_err(|err| UpstreamError::SerializeRequest(err.to_string()))?;
+        return Ok(UpstreamResponse::from_local(
+            TransformResponse::CountTokenOpenAi(response),
+        ));
+    }
+
+    let prepared =
+        GroqPreparedRequest::from_payload(payload.operation, payload.protocol, payload.body)?;
+    execute_groq_with_prepared(
+        client,
+        provider,
+        credential_states,
+        prepared,
+        payload.now_unix_ms,
+        None,
+    )
+    .await
+}
+
+async fn execute_groq_with_prepared(
+    client: &WreqClient,
+    provider: &ProviderDefinition,
+    credential_states: &ChannelCredentialStateStore,
+    prepared: GroqPreparedRequest,
+    now_unix_ms: u64,
+    cache_affinity_hint: Option<crate::channels::retry::CacheAffinityHint>,
+) -> Result<UpstreamResponse, UpstreamError> {
+    let base_url = provider.settings.base_url().trim();
+    if base_url.is_empty() {
+        return Err(UpstreamError::InvalidBaseUrl);
+    }
+    let url = join_base_url_and_path(base_url, &prepared.path);
+    let state_manager = CredentialStateManager::new(now_unix_ms);
+    let method_template = prepared.method.clone();
+    let body_template = prepared.body.clone();
+    let model_template = prepared.model.clone();
+    let url_template = url.clone();
+    let user_agent_template =
+        resolve_user_agent_or_else(provider.settings.user_agent(), default_gproxy_user_agent);
     let pick_mode =
         credential_pick_mode(provider.credential_pick_mode, cache_affinity_hint.as_ref());
 
@@ -317,6 +387,76 @@ impl GroqPreparedRequest {
                 ),
                 model: None,
             }),
+            _ => Err(UpstreamError::UnsupportedRequest),
+        }
+    }
+
+    fn from_payload(
+        operation: OperationFamily,
+        protocol: ProtocolKind,
+        body: &[u8],
+    ) -> Result<Self, UpstreamError> {
+        fn json_pointer_string(value: &Value, pointer: &str) -> Option<String> {
+            value
+                .pointer(pointer)
+                .and_then(Value::as_str)
+                .map(ToOwned::to_owned)
+        }
+
+        match (operation, protocol) {
+            (OperationFamily::ModelList, ProtocolKind::OpenAi) => Ok(Self {
+                method: WreqMethod::GET,
+                path: "/v1/models".to_string(),
+                body: None,
+                model: None,
+            }),
+            (OperationFamily::ModelGet, ProtocolKind::OpenAi) => {
+                let value = serde_json::from_slice::<Value>(body)
+                    .map_err(|err| UpstreamError::SerializeRequest(err.to_string()))?;
+                let Some(model) = json_pointer_string(&value, "/path/model") else {
+                    return Err(UpstreamError::SerializeRequest(
+                        "missing path.model in groq model_get payload".to_string(),
+                    ));
+                };
+                Ok(Self {
+                    method: WreqMethod::GET,
+                    path: format!("/v1/models/{model}"),
+                    body: None,
+                    model: Some(model),
+                })
+            }
+            (OperationFamily::GenerateContent, ProtocolKind::OpenAi)
+            | (OperationFamily::StreamGenerateContent, ProtocolKind::OpenAi) => {
+                let value = serde_json::from_slice::<Value>(body)
+                    .map_err(|err| UpstreamError::SerializeRequest(err.to_string()))?;
+                Ok(Self {
+                    method: WreqMethod::POST,
+                    path: "/v1/responses".to_string(),
+                    body: Some(normalize_response_request_body(body.to_vec())),
+                    model: json_pointer_string(&value, "/model"),
+                })
+            }
+            (OperationFamily::GenerateContent, ProtocolKind::OpenAiChatCompletion)
+            | (OperationFamily::StreamGenerateContent, ProtocolKind::OpenAiChatCompletion) => {
+                let value = serde_json::from_slice::<Value>(body)
+                    .map_err(|err| UpstreamError::SerializeRequest(err.to_string()))?;
+                Ok(Self {
+                    method: WreqMethod::POST,
+                    path: "/v1/chat/completions".to_string(),
+                    body: Some(normalize_chat_completion_request_body(body.to_vec())),
+                    model: json_pointer_string(&value, "/model"),
+                })
+            }
+            (OperationFamily::Embedding, ProtocolKind::OpenAi) => {
+                let value = serde_json::from_slice::<Value>(body)
+                    .map_err(|err| UpstreamError::SerializeRequest(err.to_string()))?;
+                Ok(Self {
+                    method: WreqMethod::POST,
+                    path: "/v1/embeddings".to_string(),
+                    body: Some(body.to_vec()),
+                    model: json_pointer_string(&value, "/model"),
+                })
+            }
             _ => Err(UpstreamError::UnsupportedRequest),
         }
     }

--- a/crates/gproxy-provider/src/channels/nvidia/mod.rs
+++ b/crates/gproxy-provider/src/channels/nvidia/mod.rs
@@ -7,4 +7,4 @@ pub mod upstream;
 pub use credential::NvidiaCredential;
 pub use dispatch::default_dispatch_table;
 pub use settings::NvidiaSettings;
-pub use upstream::execute_nvidia_with_retry;
+pub use upstream::{execute_nvidia_payload_with_retry, execute_nvidia_with_retry};

--- a/crates/gproxy-provider/src/channels/nvidia/upstream.rs
+++ b/crates/gproxy-provider/src/channels/nvidia/upstream.rs
@@ -1,4 +1,4 @@
-use gproxy_middleware::{TransformRequest, TransformResponse};
+use gproxy_middleware::{OperationFamily, ProtocolKind, TransformRequest, TransformResponse};
 use wreq::{Client as WreqClient, Method as WreqMethod};
 
 use crate::channels::retry::{
@@ -15,7 +15,7 @@ use crate::channels::utils::{
 use crate::channels::{BuiltinChannelCredential, ChannelCredential};
 use crate::credential::ChannelCredentialStateStore;
 use crate::credential_state::CredentialStateManager;
-use crate::provider::{ProviderDefinition, TokenizerResolutionContext};
+use crate::provider::{ProviderDefinition, RetryWithPayloadRequest, TokenizerResolutionContext};
 
 pub async fn try_local_nvidia_response(
     _provider: &ProviderDefinition,
@@ -65,18 +65,6 @@ pub async fn execute_nvidia_with_retry(
     }
 
     let prepared = NvidiaPreparedRequest::from_transform_request(request)?;
-    let base_url = provider.settings.base_url().trim();
-    if base_url.is_empty() {
-        return Err(UpstreamError::InvalidBaseUrl);
-    }
-    let url = join_base_url_and_path(base_url, &prepared.path);
-    let state_manager = CredentialStateManager::new(now_unix_ms);
-    let method_template = prepared.method.clone();
-    let body_template = prepared.body.clone();
-    let model_template = prepared.model.clone();
-    let url_template = url.clone();
-    let user_agent_template =
-        resolve_user_agent_or_else(provider.settings.user_agent(), default_gproxy_user_agent);
     let cache_affinity_hint = if configured_pick_mode_uses_cache(provider.credential_pick_mode) {
         crate::channels::retry::cache_affinity_protocol_from_transform_request(request).and_then(
             |protocol| {
@@ -90,6 +78,88 @@ pub async fn execute_nvidia_with_retry(
     } else {
         None
     };
+    execute_nvidia_with_prepared(
+        client,
+        provider,
+        credential_states,
+        prepared,
+        now_unix_ms,
+        cache_affinity_hint,
+    )
+    .await
+}
+
+pub async fn execute_nvidia_payload_with_retry(
+    client: &WreqClient,
+    provider: &ProviderDefinition,
+    credential_states: &ChannelCredentialStateStore,
+    payload: RetryWithPayloadRequest<'_>,
+) -> Result<UpstreamResponse, UpstreamError> {
+    if (payload.operation, payload.protocol) == (OperationFamily::CountToken, ProtocolKind::OpenAi)
+    {
+        let body_json = serde_json::from_slice::<serde_json::Value>(payload.body)
+            .map_err(|err| UpstreamError::SerializeRequest(err.to_string()))?;
+        let model = body_json
+            .get("model")
+            .and_then(serde_json::Value::as_str)
+            .map(ToOwned::to_owned);
+        let input_tokens = count_openai_input_tokens_with_resolution(
+            payload.token_resolution.tokenizer_store,
+            client,
+            payload.token_resolution.hf_token,
+            payload.token_resolution.hf_url,
+            model.as_deref(),
+            &body_json,
+        )
+        .await?;
+        let response_json = serde_json::json!({
+            "stats_code": 200,
+            "headers": { "extra": {} },
+            "body": {
+                "input_tokens": input_tokens,
+                "object": "response.input_tokens",
+            }
+        });
+        let response = serde_json::from_value(response_json)
+            .map_err(|err| UpstreamError::SerializeRequest(err.to_string()))?;
+        return Ok(UpstreamResponse::from_local(
+            TransformResponse::CountTokenOpenAi(response),
+        ));
+    }
+
+    let prepared =
+        NvidiaPreparedRequest::from_payload(payload.operation, payload.protocol, payload.body)?;
+    execute_nvidia_with_prepared(
+        client,
+        provider,
+        credential_states,
+        prepared,
+        payload.now_unix_ms,
+        None,
+    )
+    .await
+}
+
+async fn execute_nvidia_with_prepared(
+    client: &WreqClient,
+    provider: &ProviderDefinition,
+    credential_states: &ChannelCredentialStateStore,
+    prepared: NvidiaPreparedRequest,
+    now_unix_ms: u64,
+    cache_affinity_hint: Option<crate::channels::retry::CacheAffinityHint>,
+) -> Result<UpstreamResponse, UpstreamError> {
+    let base_url = provider.settings.base_url().trim();
+    if base_url.is_empty() {
+        return Err(UpstreamError::InvalidBaseUrl);
+    }
+    let url = join_base_url_and_path(base_url, &prepared.path);
+    let state_manager = CredentialStateManager::new(now_unix_ms);
+    let method_template = prepared.method.clone();
+    let body_template = prepared.body.clone();
+    let model_template = prepared.model.clone();
+    let url_template = url.clone();
+    let user_agent_template =
+        resolve_user_agent_or_else(provider.settings.user_agent(), default_gproxy_user_agent);
     let pick_mode =
         credential_pick_mode(provider.credential_pick_mode, cache_affinity_hint.as_ref());
 
@@ -285,6 +355,61 @@ impl NvidiaPreparedRequest {
                         .map_err(|err| UpstreamError::SerializeRequest(err.to_string()))?,
                 ),
                 model: Some(nvidia_embedding_model_to_string(&value.body.model)?),
+            }),
+            _ => Err(UpstreamError::UnsupportedRequest),
+        }
+    }
+
+    fn from_payload(
+        operation: OperationFamily,
+        protocol: ProtocolKind,
+        body: &[u8],
+    ) -> Result<Self, UpstreamError> {
+        fn json_pointer_string(body: &[u8], pointer: &str) -> Option<String> {
+            serde_json::from_slice::<serde_json::Value>(body)
+                .ok()
+                .and_then(|value| {
+                    value
+                        .pointer(pointer)
+                        .and_then(serde_json::Value::as_str)
+                        .map(ToOwned::to_owned)
+                })
+        }
+
+        match (operation, protocol) {
+            (OperationFamily::ModelList, ProtocolKind::OpenAi) => Ok(Self {
+                method: WreqMethod::GET,
+                path: "/v1/models".to_string(),
+                body: None,
+                model: None,
+            }),
+            (OperationFamily::ModelGet, ProtocolKind::OpenAi) => {
+                let Some(model) = json_pointer_string(body, "/path/model") else {
+                    return Err(UpstreamError::SerializeRequest(
+                        "missing path.model in nvidia model_get payload".to_string(),
+                    ));
+                };
+                Ok(Self {
+                    method: WreqMethod::GET,
+                    path: format!("/v1/models/{model}"),
+                    body: None,
+                    model: Some(model),
+                })
+            }
+            (OperationFamily::GenerateContent, ProtocolKind::OpenAiChatCompletion)
+            | (OperationFamily::StreamGenerateContent, ProtocolKind::OpenAiChatCompletion) => {
+                Ok(Self {
+                    method: WreqMethod::POST,
+                    path: "/v1/chat/completions".to_string(),
+                    body: Some(body.to_vec()),
+                    model: json_pointer_string(body, "/model"),
+                })
+            }
+            (OperationFamily::Embedding, ProtocolKind::OpenAi) => Ok(Self {
+                method: WreqMethod::POST,
+                path: "/v1/embeddings".to_string(),
+                body: Some(body.to_vec()),
+                model: json_pointer_string(body, "/model"),
             }),
             _ => Err(UpstreamError::UnsupportedRequest),
         }

--- a/crates/gproxy-provider/src/channels/openai/mod.rs
+++ b/crates/gproxy-provider/src/channels/openai/mod.rs
@@ -7,4 +7,4 @@ pub mod upstream;
 pub use credential::OpenAiCredential;
 pub use dispatch::default_dispatch_table;
 pub use settings::OpenAiSettings;
-pub use upstream::execute_openai_with_retry;
+pub use upstream::{execute_openai_payload_with_retry, execute_openai_with_retry};

--- a/crates/gproxy-provider/src/channels/openai/upstream.rs
+++ b/crates/gproxy-provider/src/channels/openai/upstream.rs
@@ -1,7 +1,7 @@
 use wreq::{Client as WreqClient, Method as WreqMethod};
 
 use crate::channels::retry::{
-    CredentialRetryDecision, cache_affinity_hint_from_transform_request,
+    CacheAffinityProtocol, CredentialRetryDecision, cache_affinity_hint_from_transform_request,
     configured_pick_mode_uses_cache, credential_pick_mode,
     retry_with_eligible_credentials_with_affinity,
 };
@@ -14,6 +14,7 @@ use crate::channels::{BuiltinChannelCredential, ChannelCredential};
 use crate::credential::ChannelCredentialStateStore;
 use crate::credential_state::CredentialStateManager;
 use crate::provider::ProviderDefinition;
+use gproxy_middleware::{OperationFamily, ProtocolKind};
 
 pub async fn execute_openai_with_retry(
     client: &WreqClient,
@@ -22,8 +23,52 @@ pub async fn execute_openai_with_retry(
     request: &gproxy_middleware::TransformRequest,
     now_unix_ms: u64,
 ) -> Result<UpstreamResponse, UpstreamError> {
+    let cache_protocol =
+        crate::channels::retry::cache_affinity_protocol_from_transform_request(request);
     let prepared =
         OpenAiPreparedRequest::from_transform_request(request)?.with_gpt5_sampling_guard();
+    execute_openai_with_prepared(
+        client,
+        provider,
+        credential_states,
+        prepared,
+        cache_protocol,
+        now_unix_ms,
+    )
+    .await
+}
+
+pub async fn execute_openai_payload_with_retry(
+    client: &WreqClient,
+    provider: &ProviderDefinition,
+    credential_states: &ChannelCredentialStateStore,
+    operation: OperationFamily,
+    protocol: ProtocolKind,
+    body: &[u8],
+    now_unix_ms: u64,
+) -> Result<UpstreamResponse, UpstreamError> {
+    let prepared =
+        OpenAiPreparedRequest::from_payload(operation, protocol, body)?.with_gpt5_sampling_guard();
+    let cache_protocol = cache_affinity_protocol_from_operation_protocol(operation, protocol);
+    execute_openai_with_prepared(
+        client,
+        provider,
+        credential_states,
+        prepared,
+        cache_protocol,
+        now_unix_ms,
+    )
+    .await
+}
+
+async fn execute_openai_with_prepared(
+    client: &WreqClient,
+    provider: &ProviderDefinition,
+    credential_states: &ChannelCredentialStateStore,
+    prepared: OpenAiPreparedRequest,
+    cache_protocol: Option<CacheAffinityProtocol>,
+    now_unix_ms: u64,
+) -> Result<UpstreamResponse, UpstreamError> {
     let base_url = provider.settings.base_url().trim();
     if base_url.is_empty() {
         return Err(UpstreamError::InvalidBaseUrl);
@@ -38,15 +83,13 @@ pub async fn execute_openai_with_retry(
     let user_agent_template =
         resolve_user_agent_or_else(provider.settings.user_agent(), default_gproxy_user_agent);
     let cache_affinity_hint = if configured_pick_mode_uses_cache(provider.credential_pick_mode) {
-        crate::channels::retry::cache_affinity_protocol_from_transform_request(request).and_then(
-            |protocol| {
-                cache_affinity_hint_from_transform_request(
-                    protocol,
-                    prepared.model.as_deref(),
-                    prepared.body.as_deref(),
-                )
-            },
-        )
+        cache_protocol.and_then(|protocol| {
+            cache_affinity_hint_from_transform_request(
+                protocol,
+                prepared.model.as_deref(),
+                prepared.body.as_deref(),
+            )
+        })
     } else {
         None
     };
@@ -196,6 +239,23 @@ pub async fn execute_openai_with_retry(
     .await
 }
 
+fn cache_affinity_protocol_from_operation_protocol(
+    operation: OperationFamily,
+    protocol: ProtocolKind,
+) -> Option<CacheAffinityProtocol> {
+    match (operation, protocol) {
+        (OperationFamily::GenerateContent, ProtocolKind::OpenAi)
+        | (OperationFamily::StreamGenerateContent, ProtocolKind::OpenAi) => {
+            Some(CacheAffinityProtocol::OpenAiResponses)
+        }
+        (OperationFamily::GenerateContent, ProtocolKind::OpenAiChatCompletion)
+        | (OperationFamily::StreamGenerateContent, ProtocolKind::OpenAiChatCompletion) => {
+            Some(CacheAffinityProtocol::OpenAiChatCompletions)
+        }
+        _ => None,
+    }
+}
+
 struct OpenAiPreparedRequest {
     method: WreqMethod,
     path: String,
@@ -300,6 +360,80 @@ impl OpenAiPreparedRequest {
                         .map_err(|err| UpstreamError::SerializeRequest(err.to_string()))?,
                 ),
                 model: Some(value.body.model.clone()),
+            }),
+            _ => Err(UpstreamError::UnsupportedRequest),
+        }
+    }
+
+    fn from_payload(
+        operation: OperationFamily,
+        protocol: ProtocolKind,
+        body: &[u8],
+    ) -> Result<Self, UpstreamError> {
+        fn json_pointer_string(body: &[u8], pointer: &str) -> Option<String> {
+            serde_json::from_slice::<serde_json::Value>(body)
+                .ok()
+                .and_then(|value| {
+                    value
+                        .pointer(pointer)
+                        .and_then(serde_json::Value::as_str)
+                        .map(ToOwned::to_owned)
+                })
+        }
+
+        match (operation, protocol) {
+            (OperationFamily::ModelList, ProtocolKind::OpenAi) => Ok(Self {
+                method: WreqMethod::GET,
+                path: "/v1/models".to_string(),
+                body: None,
+                model: None,
+            }),
+            (OperationFamily::ModelGet, ProtocolKind::OpenAi) => {
+                let Some(model) = json_pointer_string(body, "/path/model") else {
+                    return Err(UpstreamError::SerializeRequest(
+                        "missing path.model in OpenAI model get payload".to_string(),
+                    ));
+                };
+                Ok(Self {
+                    method: WreqMethod::GET,
+                    path: format!("/v1/models/{model}"),
+                    body: None,
+                    model: Some(model),
+                })
+            }
+            (OperationFamily::CountToken, ProtocolKind::OpenAi) => Ok(Self {
+                method: WreqMethod::POST,
+                path: "/v1/responses/input_tokens".to_string(),
+                body: Some(body.to_vec()),
+                model: json_pointer_string(body, "/model"),
+            }),
+            (OperationFamily::GenerateContent, ProtocolKind::OpenAi)
+            | (OperationFamily::StreamGenerateContent, ProtocolKind::OpenAi) => Ok(Self {
+                method: WreqMethod::POST,
+                path: "/v1/responses".to_string(),
+                body: Some(body.to_vec()),
+                model: json_pointer_string(body, "/model"),
+            }),
+            (OperationFamily::GenerateContent, ProtocolKind::OpenAiChatCompletion)
+            | (OperationFamily::StreamGenerateContent, ProtocolKind::OpenAiChatCompletion) => {
+                Ok(Self {
+                    method: WreqMethod::POST,
+                    path: "/v1/chat/completions".to_string(),
+                    body: Some(body.to_vec()),
+                    model: json_pointer_string(body, "/model"),
+                })
+            }
+            (OperationFamily::Embedding, ProtocolKind::OpenAi) => Ok(Self {
+                method: WreqMethod::POST,
+                path: "/v1/embeddings".to_string(),
+                body: Some(body.to_vec()),
+                model: json_pointer_string(body, "/model"),
+            }),
+            (OperationFamily::Compact, ProtocolKind::OpenAi) => Ok(Self {
+                method: WreqMethod::POST,
+                path: "/v1/responses/compact".to_string(),
+                body: Some(body.to_vec()),
+                model: json_pointer_string(body, "/model"),
             }),
             _ => Err(UpstreamError::UnsupportedRequest),
         }

--- a/crates/gproxy-provider/src/channels/vertex/mod.rs
+++ b/crates/gproxy-provider/src/channels/vertex/mod.rs
@@ -8,4 +8,7 @@ pub mod upstream;
 pub use credential::VertexServiceAccountCredential;
 pub use dispatch::default_dispatch_table;
 pub use settings::VertexSettings;
-pub use upstream::{execute_vertex_with_retry, normalize_vertex_upstream_response_body};
+pub use upstream::{
+    execute_vertex_payload_with_retry, execute_vertex_with_retry,
+    normalize_vertex_upstream_response_body,
+};

--- a/crates/gproxy-provider/src/channels/vertex/upstream.rs
+++ b/crates/gproxy-provider/src/channels/vertex/upstream.rs
@@ -1,13 +1,13 @@
-use gproxy_middleware::{TransformRequest, TransformResponse};
+use gproxy_middleware::{OperationFamily, ProtocolKind, TransformRequest, TransformResponse};
 use serde_json::{Map, Value, json};
 use wreq::{Client as WreqClient, Method as WreqMethod, Response as WreqResponse};
 
 use super::constants::DEFAULT_LOCATION;
 use super::oauth::{resolve_vertex_access_token, vertex_auth_material_from_credential};
 use crate::channels::retry::{
-    CredentialRetryDecision, cache_affinity_hint_from_transform_request,
-    configured_pick_mode_uses_cache, credential_pick_mode,
-    retry_with_eligible_credentials_with_affinity,
+    CacheAffinityProtocol, CredentialRetryDecision, cache_affinity_hint_from_transform_request,
+    cache_affinity_protocol_from_transform_request, configured_pick_mode_uses_cache,
+    credential_pick_mode, retry_with_eligible_credentials_with_affinity,
 };
 use crate::channels::upstream::{
     UpstreamCredentialUpdate, UpstreamError, UpstreamRequestMeta, UpstreamResponse,
@@ -29,7 +29,49 @@ pub async fn execute_vertex_with_retry(
     request: &TransformRequest,
     now_unix_ms: u64,
 ) -> Result<UpstreamResponse, UpstreamError> {
+    let cache_protocol = cache_affinity_protocol_from_transform_request(request);
     let prepared = VertexPreparedRequest::from_transform_request(request)?;
+    execute_vertex_with_prepared(
+        client,
+        provider,
+        credential_states,
+        prepared,
+        cache_protocol,
+        now_unix_ms,
+    )
+    .await
+}
+
+pub async fn execute_vertex_payload_with_retry(
+    client: &WreqClient,
+    provider: &ProviderDefinition,
+    credential_states: &ChannelCredentialStateStore,
+    operation: OperationFamily,
+    protocol: ProtocolKind,
+    body: &[u8],
+    now_unix_ms: u64,
+) -> Result<UpstreamResponse, UpstreamError> {
+    let prepared = VertexPreparedRequest::from_payload(operation, protocol, body)?;
+    let cache_protocol = cache_affinity_protocol_from_operation_protocol(operation, protocol);
+    execute_vertex_with_prepared(
+        client,
+        provider,
+        credential_states,
+        prepared,
+        cache_protocol,
+        now_unix_ms,
+    )
+    .await
+}
+
+async fn execute_vertex_with_prepared(
+    client: &WreqClient,
+    provider: &ProviderDefinition,
+    credential_states: &ChannelCredentialStateStore,
+    prepared: VertexPreparedRequest,
+    cache_protocol: Option<CacheAffinityProtocol>,
+    now_unix_ms: u64,
+) -> Result<UpstreamResponse, UpstreamError> {
     let base_url = provider.settings.base_url().trim();
     if base_url.is_empty() {
         return Err(UpstreamError::InvalidBaseUrl);
@@ -47,15 +89,13 @@ pub async fn execute_vertex_with_retry(
     let user_agent_template =
         resolve_user_agent_or_else(provider.settings.user_agent(), default_gproxy_user_agent);
     let cache_affinity_hint = if configured_pick_mode_uses_cache(provider.credential_pick_mode) {
-        crate::channels::retry::cache_affinity_protocol_from_transform_request(request).and_then(
-            |protocol| {
-                cache_affinity_hint_from_transform_request(
-                    protocol,
-                    prepared.model.as_deref(),
-                    prepared.body.as_deref(),
-                )
-            },
-        )
+        cache_protocol.and_then(|protocol| {
+            cache_affinity_hint_from_transform_request(
+                protocol,
+                prepared.model.as_deref(),
+                prepared.body.as_deref(),
+            )
+        })
     } else {
         None
     };
@@ -428,6 +468,24 @@ pub async fn execute_vertex_with_retry(
     .await
 }
 
+fn cache_affinity_protocol_from_operation_protocol(
+    operation: OperationFamily,
+    protocol: ProtocolKind,
+) -> Option<CacheAffinityProtocol> {
+    match (operation, protocol) {
+        (OperationFamily::GenerateContent, ProtocolKind::Gemini)
+        | (OperationFamily::StreamGenerateContent, ProtocolKind::Gemini)
+        | (OperationFamily::StreamGenerateContent, ProtocolKind::GeminiNDJson) => {
+            Some(CacheAffinityProtocol::GeminiGenerateContent)
+        }
+        (OperationFamily::GenerateContent, ProtocolKind::OpenAiChatCompletion)
+        | (OperationFamily::StreamGenerateContent, ProtocolKind::OpenAiChatCompletion) => {
+            Some(CacheAffinityProtocol::OpenAiChatCompletions)
+        }
+        _ => None,
+    }
+}
+
 fn vertex_credential_update(
     credential_id: i64,
     access_token: &str,
@@ -617,6 +675,146 @@ impl VertexPreparedRequest {
                             .map_err(|err| UpstreamError::SerializeRequest(err.to_string()))?,
                     ),
                     model: Some(body.model.clone()),
+                    model_response_kind: None,
+                })
+            }
+            _ => Err(UpstreamError::UnsupportedRequest),
+        }
+    }
+
+    fn from_payload(
+        operation: OperationFamily,
+        protocol: ProtocolKind,
+        body: &[u8],
+    ) -> Result<Self, UpstreamError> {
+        fn parse_gemini_payload_wrapper(
+            payload: &[u8],
+        ) -> Result<(String, Value, Option<String>), UpstreamError> {
+            let value = serde_json::from_slice::<Value>(payload)
+                .map_err(|err| UpstreamError::SerializeRequest(err.to_string()))?;
+            let Some(model) = value
+                .pointer("/path/model")
+                .and_then(Value::as_str)
+                .map(ToOwned::to_owned)
+            else {
+                return Err(UpstreamError::SerializeRequest(
+                    "missing path.model in Gemini payload".to_string(),
+                ));
+            };
+            let Some(body_value) = value.get("body").cloned() else {
+                return Err(UpstreamError::SerializeRequest(
+                    "missing body in Gemini payload".to_string(),
+                ));
+            };
+            let alt = value
+                .pointer("/query/alt")
+                .and_then(Value::as_str)
+                .map(ToOwned::to_owned);
+            Ok((model, body_value, alt))
+        }
+
+        match (operation, protocol) {
+            (OperationFamily::CountToken, ProtocolKind::Gemini) => {
+                let (model, body_value, _) = parse_gemini_payload_wrapper(body)?;
+                let model_id = normalize_vertex_model_name(model.as_str());
+                let body = vertex_count_tokens_payload(model_id.as_str(), &body_value)?;
+                Ok(Self {
+                    method: WreqMethod::POST,
+                    endpoint: VertexEndpoint::Project(format!(
+                        "publishers/google/models/{model_id}:countTokens"
+                    )),
+                    query: None,
+                    body: Some(
+                        serde_json::to_vec(&body)
+                            .map_err(|err| UpstreamError::SerializeRequest(err.to_string()))?,
+                    ),
+                    model: Some(model_id),
+                    model_response_kind: None,
+                })
+            }
+            (OperationFamily::GenerateContent, ProtocolKind::Gemini) => {
+                let (model, body_value, _) = parse_gemini_payload_wrapper(body)?;
+                let model_id = normalize_vertex_model_name(model.as_str());
+                let body = vertex_generate_payload(model_id.as_str(), &body_value)?;
+                Ok(Self {
+                    method: WreqMethod::POST,
+                    endpoint: VertexEndpoint::Project(format!(
+                        "publishers/google/models/{model_id}:generateContent"
+                    )),
+                    query: None,
+                    body: Some(
+                        serde_json::to_vec(&body)
+                            .map_err(|err| UpstreamError::SerializeRequest(err.to_string()))?,
+                    ),
+                    model: Some(model_id),
+                    model_response_kind: None,
+                })
+            }
+            (OperationFamily::StreamGenerateContent, ProtocolKind::Gemini)
+            | (OperationFamily::StreamGenerateContent, ProtocolKind::GeminiNDJson) => {
+                let (model, body_value, alt) = parse_gemini_payload_wrapper(body)?;
+                let model_id = normalize_vertex_model_name(model.as_str());
+                let body = vertex_generate_payload(model_id.as_str(), &body_value)?;
+                let query = match protocol {
+                    ProtocolKind::Gemini => Some("alt=sse".to_string()),
+                    ProtocolKind::GeminiNDJson => alt.map(|_| "alt=sse".to_string()),
+                    _ => None,
+                };
+                Ok(Self {
+                    method: WreqMethod::POST,
+                    endpoint: VertexEndpoint::Project(format!(
+                        "publishers/google/models/{model_id}:streamGenerateContent"
+                    )),
+                    query,
+                    body: Some(
+                        serde_json::to_vec(&body)
+                            .map_err(|err| UpstreamError::SerializeRequest(err.to_string()))?,
+                    ),
+                    model: Some(model_id),
+                    model_response_kind: None,
+                })
+            }
+            (OperationFamily::Embedding, ProtocolKind::Gemini) => {
+                let (model, body_value, _) = parse_gemini_payload_wrapper(body)?;
+                let model_id = normalize_vertex_model_name(model.as_str());
+                let body = vertex_embedding_predict_payload(&body_value)?;
+                Ok(Self {
+                    method: WreqMethod::POST,
+                    endpoint: VertexEndpoint::Project(format!(
+                        "publishers/google/models/{model_id}:predict"
+                    )),
+                    query: None,
+                    body: Some(
+                        serde_json::to_vec(&body)
+                            .map_err(|err| UpstreamError::SerializeRequest(err.to_string()))?,
+                    ),
+                    model: Some(model_id),
+                    model_response_kind: Some(VertexModelResponseKind::Embedding),
+                })
+            }
+            (OperationFamily::GenerateContent, ProtocolKind::OpenAiChatCompletion)
+            | (OperationFamily::StreamGenerateContent, ProtocolKind::OpenAiChatCompletion) => {
+                let mut body_json = serde_json::from_slice::<Value>(body)
+                    .map_err(|err| UpstreamError::SerializeRequest(err.to_string()))?;
+                let mut model: Option<String> = None;
+                if let Some(map) = body_json.as_object_mut()
+                    && let Some(raw_model) = map.get("model").and_then(Value::as_str)
+                {
+                    let normalized = normalize_vertex_openai_model(raw_model);
+                    map.insert("model".to_string(), Value::String(normalized.clone()));
+                    model = Some(normalized);
+                }
+                Ok(Self {
+                    method: WreqMethod::POST,
+                    endpoint: VertexEndpoint::Project(
+                        "endpoints/openapi/chat/completions".to_string(),
+                    ),
+                    query: None,
+                    body: Some(
+                        serde_json::to_vec(&body_json)
+                            .map_err(|err| UpstreamError::SerializeRequest(err.to_string()))?,
+                    ),
+                    model,
                     model_response_kind: None,
                 })
             }

--- a/crates/gproxy-provider/src/channels/vertexexpress/mod.rs
+++ b/crates/gproxy-provider/src/channels/vertexexpress/mod.rs
@@ -7,4 +7,7 @@ pub mod upstream;
 pub use credential::VertexExpressCredential;
 pub use dispatch::default_dispatch_table;
 pub use settings::VertexExpressSettings;
-pub use upstream::{execute_vertexexpress_with_retry, try_local_vertexexpress_model_response};
+pub use upstream::{
+    execute_vertexexpress_payload_with_retry, execute_vertexexpress_with_retry,
+    try_local_vertexexpress_model_response,
+};

--- a/crates/gproxy-provider/src/channels/vertexexpress/upstream.rs
+++ b/crates/gproxy-provider/src/channels/vertexexpress/upstream.rs
@@ -1,12 +1,12 @@
-use gproxy_middleware::{TransformRequest, TransformResponse};
+use gproxy_middleware::{OperationFamily, ProtocolKind, TransformRequest, TransformResponse};
 use serde_json::{Map, Value};
 use wreq::{Client as WreqClient, Method as WreqMethod};
 
 use super::constants::MODELS_GEMINI_JSON;
 use crate::channels::retry::{
-    CredentialRetryDecision, cache_affinity_hint_from_transform_request,
-    configured_pick_mode_uses_cache, credential_pick_mode,
-    retry_with_eligible_credentials_with_affinity,
+    CacheAffinityProtocol, CredentialRetryDecision, cache_affinity_hint_from_transform_request,
+    cache_affinity_protocol_from_transform_request, configured_pick_mode_uses_cache,
+    credential_pick_mode, retry_with_eligible_credentials_with_affinity,
 };
 use crate::channels::upstream::{UpstreamError, UpstreamResponse};
 use crate::channels::utils::{
@@ -37,7 +37,49 @@ pub async fn execute_vertexexpress_with_retry(
         return Ok(UpstreamResponse::from_local(local));
     }
 
+    let cache_protocol = cache_affinity_protocol_from_transform_request(request);
     let prepared = VertexExpressPreparedRequest::from_transform_request(request)?;
+    execute_vertexexpress_with_prepared(
+        client,
+        provider,
+        credential_states,
+        prepared,
+        cache_protocol,
+        now_unix_ms,
+    )
+    .await
+}
+
+pub async fn execute_vertexexpress_payload_with_retry(
+    client: &WreqClient,
+    provider: &ProviderDefinition,
+    credential_states: &ChannelCredentialStateStore,
+    operation: OperationFamily,
+    protocol: ProtocolKind,
+    body: &[u8],
+    now_unix_ms: u64,
+) -> Result<UpstreamResponse, UpstreamError> {
+    let prepared = VertexExpressPreparedRequest::from_payload(operation, protocol, body)?;
+    let cache_protocol = cache_affinity_protocol_from_operation_protocol(operation, protocol);
+    execute_vertexexpress_with_prepared(
+        client,
+        provider,
+        credential_states,
+        prepared,
+        cache_protocol,
+        now_unix_ms,
+    )
+    .await
+}
+
+async fn execute_vertexexpress_with_prepared(
+    client: &WreqClient,
+    provider: &ProviderDefinition,
+    credential_states: &ChannelCredentialStateStore,
+    prepared: VertexExpressPreparedRequest,
+    cache_protocol: Option<CacheAffinityProtocol>,
+    now_unix_ms: u64,
+) -> Result<UpstreamResponse, UpstreamError> {
     let base_url = provider.settings.base_url().trim();
     if base_url.is_empty() {
         return Err(UpstreamError::InvalidBaseUrl);
@@ -53,15 +95,13 @@ pub async fn execute_vertexexpress_with_retry(
     let user_agent_template =
         resolve_user_agent_or_else(provider.settings.user_agent(), default_gproxy_user_agent);
     let cache_affinity_hint = if configured_pick_mode_uses_cache(provider.credential_pick_mode) {
-        crate::channels::retry::cache_affinity_protocol_from_transform_request(request).and_then(
-            |protocol| {
-                cache_affinity_hint_from_transform_request(
-                    protocol,
-                    prepared.model.as_deref(),
-                    prepared.body.as_deref(),
-                )
-            },
-        )
+        cache_protocol.and_then(|protocol| {
+            cache_affinity_hint_from_transform_request(
+                protocol,
+                prepared.model.as_deref(),
+                prepared.body.as_deref(),
+            )
+        })
     } else {
         None
     };
@@ -219,6 +259,20 @@ pub async fn execute_vertexexpress_with_retry(
     .await
 }
 
+fn cache_affinity_protocol_from_operation_protocol(
+    operation: OperationFamily,
+    protocol: ProtocolKind,
+) -> Option<CacheAffinityProtocol> {
+    match (operation, protocol) {
+        (OperationFamily::GenerateContent, ProtocolKind::Gemini)
+        | (OperationFamily::StreamGenerateContent, ProtocolKind::Gemini)
+        | (OperationFamily::StreamGenerateContent, ProtocolKind::GeminiNDJson) => {
+            Some(CacheAffinityProtocol::GeminiGenerateContent)
+        }
+        _ => None,
+    }
+}
+
 struct VertexExpressPreparedRequest {
     method: WreqMethod,
     path: String,
@@ -305,6 +359,97 @@ impl VertexExpressPreparedRequest {
                         "/v1beta1/publishers/google/models/{model_id}:streamGenerateContent"
                     ),
                     query: value.query.alt.as_ref().map(|_| "alt=sse".to_string()),
+                    body: Some(
+                        serde_json::to_vec(&body)
+                            .map_err(|err| UpstreamError::SerializeRequest(err.to_string()))?,
+                    ),
+                    model: Some(format!("models/{model_id}")),
+                })
+            }
+            _ => Err(UpstreamError::UnsupportedRequest),
+        }
+    }
+
+    fn from_payload(
+        operation: OperationFamily,
+        protocol: ProtocolKind,
+        body: &[u8],
+    ) -> Result<Self, UpstreamError> {
+        fn parse_gemini_payload_wrapper(
+            payload: &[u8],
+        ) -> Result<(String, Value, Option<String>), UpstreamError> {
+            let value = serde_json::from_slice::<Value>(payload)
+                .map_err(|err| UpstreamError::SerializeRequest(err.to_string()))?;
+            let Some(model) = value
+                .pointer("/path/model")
+                .and_then(Value::as_str)
+                .map(ToOwned::to_owned)
+            else {
+                return Err(UpstreamError::SerializeRequest(
+                    "missing path.model in Gemini payload".to_string(),
+                ));
+            };
+            let Some(body_value) = value.get("body").cloned() else {
+                return Err(UpstreamError::SerializeRequest(
+                    "missing body in Gemini payload".to_string(),
+                ));
+            };
+            let alt = value
+                .pointer("/query/alt")
+                .and_then(Value::as_str)
+                .map(ToOwned::to_owned);
+            Ok((model, body_value, alt))
+        }
+
+        match (operation, protocol) {
+            (OperationFamily::CountToken, ProtocolKind::Gemini) => {
+                let (model, body_value, _) = parse_gemini_payload_wrapper(body)?;
+                let model_id = vertexexpress_model_id(model.as_str());
+                Ok(Self {
+                    method: WreqMethod::POST,
+                    path: format!("/v1beta1/publishers/google/models/{model_id}:countTokens"),
+                    query: None,
+                    body: Some(
+                        serde_json::to_vec(&vertex_count_tokens_payload(
+                            model_id.as_str(),
+                            &body_value,
+                        )?)
+                        .map_err(|err| UpstreamError::SerializeRequest(err.to_string()))?,
+                    ),
+                    model: Some(format!("models/{model_id}")),
+                })
+            }
+            (OperationFamily::GenerateContent, ProtocolKind::Gemini) => {
+                let (model, body_value, _) = parse_gemini_payload_wrapper(body)?;
+                let model_id = vertexexpress_model_id(model.as_str());
+                let body = vertex_generate_payload(model_id.as_str(), &body_value)?;
+                Ok(Self {
+                    method: WreqMethod::POST,
+                    path: format!("/v1beta1/publishers/google/models/{model_id}:generateContent"),
+                    query: None,
+                    body: Some(
+                        serde_json::to_vec(&body)
+                            .map_err(|err| UpstreamError::SerializeRequest(err.to_string()))?,
+                    ),
+                    model: Some(format!("models/{model_id}")),
+                })
+            }
+            (OperationFamily::StreamGenerateContent, ProtocolKind::Gemini)
+            | (OperationFamily::StreamGenerateContent, ProtocolKind::GeminiNDJson) => {
+                let (model, body_value, alt) = parse_gemini_payload_wrapper(body)?;
+                let model_id = vertexexpress_model_id(model.as_str());
+                let body = vertex_generate_payload(model_id.as_str(), &body_value)?;
+                let query = match protocol {
+                    ProtocolKind::Gemini => Some("alt=sse".to_string()),
+                    ProtocolKind::GeminiNDJson => alt.map(|_| "alt=sse".to_string()),
+                    _ => None,
+                };
+                Ok(Self {
+                    method: WreqMethod::POST,
+                    path: format!(
+                        "/v1beta1/publishers/google/models/{model_id}:streamGenerateContent"
+                    ),
+                    query,
                     body: Some(
                         serde_json::to_vec(&body)
                             .map_err(|err| UpstreamError::SerializeRequest(err.to_string()))?,

--- a/crates/gproxy-provider/src/lib.rs
+++ b/crates/gproxy-provider/src/lib.rs
@@ -36,7 +36,9 @@ pub use facade::{
     normalize_upstream_response_body_for_channel,
     normalize_upstream_stream_ndjson_chunk_for_channel, try_local_response_for_channel,
 };
-pub use provider::{ProviderDefinition, ProviderRegistry, TokenizerResolutionContext};
+pub use provider::{
+    ProviderDefinition, ProviderRegistry, RetryWithPayloadRequest, TokenizerResolutionContext,
+};
 pub use settings::{
     CREDENTIAL_PICK_MODE_KEY, parse_credential_pick_mode_from_provider_settings_value,
     parse_provider_settings_json_for_channel, parse_provider_settings_value_for_channel,

--- a/crates/gproxy-provider/src/provider.rs
+++ b/crates/gproxy-provider/src/provider.rs
@@ -1,41 +1,47 @@
 use crate::UpstreamCredentialUpdate;
 use crate::channel::ChannelId;
 use crate::channels::ChannelSettings;
-use crate::channels::aistudio::execute_aistudio_with_retry;
+use crate::channels::aistudio::{execute_aistudio_payload_with_retry, execute_aistudio_with_retry};
 use crate::channels::antigravity::{
     execute_antigravity_oauth_callback, execute_antigravity_oauth_start,
-    execute_antigravity_upstream_usage_with_retry, execute_antigravity_with_retry,
+    execute_antigravity_payload_with_retry, execute_antigravity_upstream_usage_with_retry,
+    execute_antigravity_with_retry,
 };
-use crate::channels::claude::execute_claude_with_retry;
+use crate::channels::claude::{execute_claude_payload_with_retry, execute_claude_with_retry};
 use crate::channels::claudecode::credential::ClaudeCodeTokenRefresh;
 use crate::channels::claudecode::{
     execute_claudecode_oauth_callback, execute_claudecode_oauth_start,
-    execute_claudecode_upstream_usage_with_retry, execute_claudecode_with_retry,
+    execute_claudecode_payload_with_retry, execute_claudecode_upstream_usage_with_retry,
+    execute_claudecode_with_retry,
 };
 use crate::channels::codex::{
-    execute_codex_oauth_callback, execute_codex_oauth_start,
+    execute_codex_oauth_callback, execute_codex_oauth_start, execute_codex_payload_with_retry,
     execute_codex_upstream_usage_with_retry, execute_codex_with_retry,
 };
 use crate::channels::custom::execute_custom_with_retry;
-use crate::channels::deepseek::execute_deepseek_with_retry;
+use crate::channels::deepseek::{execute_deepseek_payload_with_retry, execute_deepseek_with_retry};
 use crate::channels::geminicli::{
     execute_geminicli_oauth_callback, execute_geminicli_oauth_start,
-    execute_geminicli_upstream_usage_with_retry, execute_geminicli_with_retry,
+    execute_geminicli_payload_with_retry, execute_geminicli_upstream_usage_with_retry,
+    execute_geminicli_with_retry,
 };
-use crate::channels::groq::execute_groq_with_retry;
-use crate::channels::nvidia::execute_nvidia_with_retry;
-use crate::channels::openai::execute_openai_with_retry;
+use crate::channels::groq::{execute_groq_payload_with_retry, execute_groq_with_retry};
+use crate::channels::nvidia::{execute_nvidia_payload_with_retry, execute_nvidia_with_retry};
+use crate::channels::openai::{execute_openai_payload_with_retry, execute_openai_with_retry};
 use crate::channels::retry::CredentialPickMode;
 use crate::channels::upstream::{
     UpstreamError, UpstreamOAuthCallbackResult, UpstreamOAuthRequest, UpstreamOAuthResponse,
     UpstreamResponse,
 };
-use crate::channels::vertex::execute_vertex_with_retry;
-use crate::channels::vertexexpress::execute_vertexexpress_with_retry;
+use crate::channels::vertex::{execute_vertex_payload_with_retry, execute_vertex_with_retry};
+use crate::channels::vertexexpress::{
+    execute_vertexexpress_payload_with_retry, execute_vertexexpress_with_retry,
+};
 use crate::channels::{BuiltinChannelCredential, ChannelCredential};
 use crate::credential::{CredentialRef, ProviderCredentialState};
 use crate::dispatch::ProviderDispatchTable;
 use crate::tokenizers::LocalTokenizerStore;
+use gproxy_middleware::{OperationFamily, ProtocolKind};
 use wreq::Client as WreqClient;
 
 #[derive(Debug, Clone, Copy)]
@@ -43,6 +49,15 @@ pub struct TokenizerResolutionContext<'a> {
     pub tokenizer_store: &'a LocalTokenizerStore,
     pub hf_token: Option<&'a str>,
     pub hf_url: Option<&'a str>,
+}
+
+#[derive(Debug, Clone, Copy)]
+pub struct RetryWithPayloadRequest<'a> {
+    pub operation: OperationFamily,
+    pub protocol: ProtocolKind,
+    pub body: &'a [u8],
+    pub now_unix_ms: u64,
+    pub token_resolution: TokenizerResolutionContext<'a>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -511,6 +526,124 @@ impl ProviderDefinition {
                 execute_custom_with_retry(client, self, credential_states, request, now_unix_ms)
                     .await
             }
+        }
+    }
+
+    pub async fn execute_payload_with_retry_with_spoof(
+        &self,
+        client: &WreqClient,
+        spoof_client: Option<&WreqClient>,
+        credential_states: &crate::credential::ChannelCredentialStateStore,
+        payload: RetryWithPayloadRequest<'_>,
+    ) -> Result<UpstreamResponse, UpstreamError> {
+        match &self.channel {
+            ChannelId::Builtin(crate::channel::BuiltinChannel::OpenAi) => {
+                execute_openai_payload_with_retry(
+                    client,
+                    self,
+                    credential_states,
+                    payload.operation,
+                    payload.protocol,
+                    payload.body,
+                    payload.now_unix_ms,
+                )
+                .await
+            }
+            ChannelId::Builtin(crate::channel::BuiltinChannel::Claude) => {
+                execute_claude_payload_with_retry(
+                    client,
+                    self,
+                    credential_states,
+                    payload.operation,
+                    payload.protocol,
+                    payload.body,
+                    payload.now_unix_ms,
+                )
+                .await
+            }
+            ChannelId::Builtin(crate::channel::BuiltinChannel::ClaudeCode) => {
+                execute_claudecode_payload_with_retry(
+                    client,
+                    spoof_client.unwrap_or(client),
+                    self,
+                    credential_states,
+                    payload,
+                )
+                .await
+            }
+            ChannelId::Builtin(crate::channel::BuiltinChannel::AiStudio) => {
+                execute_aistudio_payload_with_retry(
+                    client,
+                    self,
+                    credential_states,
+                    payload.operation,
+                    payload.protocol,
+                    payload.body,
+                    payload.now_unix_ms,
+                )
+                .await
+            }
+            ChannelId::Builtin(crate::channel::BuiltinChannel::GeminiCli) => {
+                execute_geminicli_payload_with_retry(
+                    client,
+                    self,
+                    credential_states,
+                    payload.operation,
+                    payload.protocol,
+                    payload.body,
+                    payload.now_unix_ms,
+                )
+                .await
+            }
+            ChannelId::Builtin(crate::channel::BuiltinChannel::Codex) => {
+                execute_codex_payload_with_retry(client, self, credential_states, payload).await
+            }
+            ChannelId::Builtin(crate::channel::BuiltinChannel::VertexExpress) => {
+                execute_vertexexpress_payload_with_retry(
+                    client,
+                    self,
+                    credential_states,
+                    payload.operation,
+                    payload.protocol,
+                    payload.body,
+                    payload.now_unix_ms,
+                )
+                .await
+            }
+            ChannelId::Builtin(crate::channel::BuiltinChannel::Vertex) => {
+                execute_vertex_payload_with_retry(
+                    client,
+                    self,
+                    credential_states,
+                    payload.operation,
+                    payload.protocol,
+                    payload.body,
+                    payload.now_unix_ms,
+                )
+                .await
+            }
+            ChannelId::Builtin(crate::channel::BuiltinChannel::Antigravity) => {
+                execute_antigravity_payload_with_retry(
+                    client,
+                    self,
+                    credential_states,
+                    payload.operation,
+                    payload.protocol,
+                    payload.body,
+                    payload.now_unix_ms,
+                )
+                .await
+            }
+            ChannelId::Builtin(crate::channel::BuiltinChannel::Nvidia) => {
+                execute_nvidia_payload_with_retry(client, self, credential_states, payload).await
+            }
+            ChannelId::Builtin(crate::channel::BuiltinChannel::Deepseek) => {
+                execute_deepseek_payload_with_retry(client, self, credential_states, payload).await
+            }
+            ChannelId::Builtin(crate::channel::BuiltinChannel::Groq) => {
+                execute_groq_payload_with_retry(client, self, credential_states, payload).await
+            }
+            _ => Err(UpstreamError::UnsupportedRequest),
         }
     }
 }


### PR DESCRIPTION
- Introduced `execute_nvidia_payload_with_retry`, `execute_openai_payload_with_retry`, `execute_vertex_payload_with_retry`, and `execute_vertexexpress_payload_with_retry` to handle payload-based requests.
- Updated existing upstream execution methods to utilize the new payload-based methods.
- Enhanced error handling and request preparation for payloads across different channels.
- Refactored cache affinity logic to accommodate new payload execution paths.
- Added support for new operation families and protocols in the request preparation logic.