### PR TITLE
fix(http_client): constrain provider redirects to same endpoint

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,7 @@
 name: ci
 
 on:
+  workflow_dispatch:
   pull_request:
     branches:
       - main

--- a/sdk/gproxy-channel/src/executor.rs
+++ b/sdk/gproxy-channel/src/executor.rs
@@ -38,7 +38,7 @@
 //! ```
 
 use crate::channel::{Channel, ChannelSettings};
-use crate::http_client::{send_request, send_request_stream};
+use crate::http_client::{send_provider_request, send_provider_request_stream};
 use crate::request::PreparedRequest;
 use crate::response::{
     ResponseClassification, RetryableUpstreamResponse, UpstreamError, UpstreamResponse,
@@ -187,7 +187,7 @@ pub async fn send_attempt<C: Channel>(
         http_client
     };
 
-    let raw = send_request(active_client, http_request).await?;
+    let raw = send_provider_request(active_client, http_request).await?;
     let normalized_body = channel.normalize_response(request, raw.body);
     let classification = channel.classify_response(raw.status, &raw.headers, &normalized_body);
 
@@ -222,7 +222,7 @@ pub async fn send_attempt_stream<C: Channel>(
         http_client
     };
 
-    match send_request_stream(active_client, http_request).await? {
+    match send_provider_request_stream(active_client, http_request).await? {
         RetryableUpstreamResponse::Streaming(stream) => {
             Ok(SendAttemptStreamOutcome::Streaming(stream))
         }

--- a/sdk/gproxy-channel/src/http_client.rs
+++ b/sdk/gproxy-channel/src/http_client.rs
@@ -1,16 +1,109 @@
 use futures_util::TryStreamExt;
+use http::Uri;
 
 use crate::response::{
     RetryableUpstreamResponse, UpstreamError, UpstreamResponse, UpstreamStreamingResponse,
 };
+
+fn normalize_redirect_path(path: &str) -> &str {
+    if path.len() > 1 {
+        path.trim_end_matches('/')
+    } else {
+        path
+    }
+}
+
+fn safe_provider_redirect_policy(original_uri: Uri) -> wreq::redirect::Policy {
+    wreq::redirect::Policy::custom(move |attempt| {
+        if attempt.previous.len() > 10 {
+            return attempt.error("too many redirects");
+        }
+
+        let next = attempt.uri.as_ref();
+        let original_scheme = original_uri.scheme_str();
+        let next_scheme = next.scheme_str();
+        let same_host = original_uri.host() == next.host();
+        let scheme_allowed = original_scheme == next_scheme
+            || matches!(
+                (original_scheme, next_scheme),
+                (Some("http"), Some("https"))
+            );
+        let same_endpoint =
+            normalize_redirect_path(original_uri.path()) == normalize_redirect_path(next.path());
+
+        if same_host && scheme_allowed && same_endpoint {
+            attempt.follow()
+        } else {
+            attempt.stop()
+        }
+    })
+}
+
+fn build_wreq_request(
+    client: &wreq::Client,
+    request: http::Request<Vec<u8>>,
+    redirect_policy: wreq::redirect::Policy,
+) -> Result<wreq::Request, UpstreamError> {
+    let (parts, body) = request.into_parts();
+
+    // Provider traffic must not blindly inherit the engine's global
+    // redirect policy. On shared reverse-proxy domains, silently
+    // following 3xx responses can move a request onto a different
+    // provider endpoint while the engine still logs the original URI.
+    client
+        .request(parts.method, parts.uri)
+        .headers(parts.headers)
+        .version(parts.version)
+        .redirect(redirect_policy)
+        .body(body)
+        .build()
+        .map_err(|e| UpstreamError::RequestBuild(e.to_string()))
+}
 
 /// Send an `http::Request<Vec<u8>>` via wreq and return an `UpstreamResponse`.
 pub async fn send_request(
     client: &wreq::Client,
     request: http::Request<Vec<u8>>,
 ) -> Result<UpstreamResponse, UpstreamError> {
+    send_request_with_policy(client, request, wreq::redirect::Policy::limited(10)).await
+}
+
+/// Send a provider-bound request via wreq using a conservative redirect
+/// policy that only allows same-endpoint canonicalization redirects.
+pub async fn send_provider_request(
+    client: &wreq::Client,
+    request: http::Request<Vec<u8>>,
+) -> Result<UpstreamResponse, UpstreamError> {
+    let redirect_policy = safe_provider_redirect_policy(request.uri().clone());
+    send_request_with_policy(client, request, redirect_policy).await
+}
+
+/// Send an `http::Request<Vec<u8>>` via wreq and keep successful responses as
+/// a byte stream. Non-success responses are buffered so retry logic can inspect
+/// the body.
+pub async fn send_request_stream(
+    client: &wreq::Client,
+    request: http::Request<Vec<u8>>,
+) -> Result<RetryableUpstreamResponse, UpstreamError> {
+    send_request_stream_with_policy(client, request, wreq::redirect::Policy::limited(10)).await
+}
+
+/// Streaming counterpart of [`send_provider_request`].
+pub async fn send_provider_request_stream(
+    client: &wreq::Client,
+    request: http::Request<Vec<u8>>,
+) -> Result<RetryableUpstreamResponse, UpstreamError> {
+    let redirect_policy = safe_provider_redirect_policy(request.uri().clone());
+    send_request_stream_with_policy(client, request, redirect_policy).await
+}
+
+async fn send_request_with_policy(
+    client: &wreq::Client,
+    request: http::Request<Vec<u8>>,
+    redirect_policy: wreq::redirect::Policy,
+) -> Result<UpstreamResponse, UpstreamError> {
     let started_at = std::time::Instant::now();
-    let wreq_request = wreq::Request::from(request);
+    let wreq_request = build_wreq_request(client, request, redirect_policy)?;
 
     let response = client
         .execute(wreq_request)
@@ -36,15 +129,13 @@ pub async fn send_request(
     })
 }
 
-/// Send an `http::Request<Vec<u8>>` via wreq and keep successful responses as
-/// a byte stream. Non-success responses are buffered so retry logic can inspect
-/// the body.
-pub async fn send_request_stream(
+async fn send_request_stream_with_policy(
     client: &wreq::Client,
     request: http::Request<Vec<u8>>,
+    redirect_policy: wreq::redirect::Policy,
 ) -> Result<RetryableUpstreamResponse, UpstreamError> {
     let started_at = std::time::Instant::now();
-    let wreq_request = wreq::Request::from(request);
+    let wreq_request = build_wreq_request(client, request, redirect_policy)?;
 
     let response = client
         .execute(wreq_request)

--- a/sdk/gproxy-channel/tests/http_client_redirect.rs
+++ b/sdk/gproxy-channel/tests/http_client_redirect.rs
@@ -1,0 +1,129 @@
+use std::sync::Arc;
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+use axum::Router;
+use axum::extract::State;
+use axum::http::{StatusCode, header};
+use axum::routing::get;
+use tokio::net::TcpListener;
+
+use gproxy_channel::http_client::send_provider_request;
+
+#[derive(Default)]
+struct RedirectState {
+    redirect_hits: AtomicUsize,
+    wrong_path_hits: AtomicUsize,
+    canonical_hits: AtomicUsize,
+}
+
+async fn redirect_handler(
+    State(state): State<Arc<RedirectState>>,
+) -> (
+    StatusCode,
+    [(header::HeaderName, &'static str); 1],
+    &'static str,
+) {
+    state.redirect_hits.fetch_add(1, Ordering::Relaxed);
+    (
+        StatusCode::FOUND,
+        [(header::LOCATION, "/v1/messages")],
+        "redirecting",
+    )
+}
+
+async fn wrong_path_handler(State(state): State<Arc<RedirectState>>) -> &'static str {
+    state.wrong_path_hits.fetch_add(1, Ordering::Relaxed);
+    "wrong path reached"
+}
+
+async fn canonical_target_handler(State(state): State<Arc<RedirectState>>) -> &'static str {
+    state.canonical_hits.fetch_add(1, Ordering::Relaxed);
+    "canonical path reached"
+}
+
+async fn start_redirect_server() -> (String, Arc<RedirectState>) {
+    let state = Arc::new(RedirectState::default());
+    let app = Router::new()
+        .route("/v1/chat/completions", get(redirect_handler))
+        .route("/v1/messages", get(wrong_path_handler))
+        .route("/v1/chat/completions/", get(canonical_target_handler))
+        .with_state(state.clone());
+
+    let listener = TcpListener::bind("127.0.0.1:0").await.expect("bind");
+    let addr = listener.local_addr().expect("local_addr");
+    tokio::spawn(async move {
+        axum::serve(listener, app).await.expect("axum::serve");
+    });
+
+    (format!("http://{addr}"), state)
+}
+
+#[tokio::test]
+async fn provider_requests_block_cross_endpoint_redirects() {
+    let (base_url, state) = start_redirect_server().await;
+
+    let client = wreq::Client::builder()
+        .redirect(wreq::redirect::Policy::limited(10))
+        .build()
+        .expect("client");
+
+    let request = http::Request::builder()
+        .method(http::Method::GET)
+        .uri(format!("{base_url}/v1/chat/completions"))
+        .body(Vec::new())
+        .expect("request");
+
+    let response = send_provider_request(&client, request)
+        .await
+        .expect("response");
+
+    assert_eq!(response.status, StatusCode::FOUND.as_u16());
+    assert_eq!(state.redirect_hits.load(Ordering::Relaxed), 1);
+    assert_eq!(
+        state.wrong_path_hits.load(Ordering::Relaxed),
+        0,
+        "the HTTP client followed a redirect and hit the wrong path"
+    );
+}
+
+#[tokio::test]
+async fn provider_requests_allow_same_endpoint_canonicalization_redirects() {
+    let state = Arc::new(RedirectState::default());
+    let app = Router::new()
+        .route(
+            "/v1/chat/completions",
+            get(|| async {
+                (
+                    StatusCode::FOUND,
+                    [(header::LOCATION, "/v1/chat/completions/")],
+                    "redirecting",
+                )
+            }),
+        )
+        .route("/v1/chat/completions/", get(canonical_target_handler))
+        .with_state(state.clone());
+
+    let listener = TcpListener::bind("127.0.0.1:0").await.expect("bind");
+    let addr = listener.local_addr().expect("local_addr");
+    tokio::spawn(async move {
+        axum::serve(listener, app).await.expect("axum::serve");
+    });
+
+    let client = wreq::Client::builder()
+        .redirect(wreq::redirect::Policy::limited(10))
+        .build()
+        .expect("client");
+
+    let request = http::Request::builder()
+        .method(http::Method::GET)
+        .uri(format!("http://{addr}/v1/chat/completions"))
+        .body(Vec::new())
+        .expect("request");
+
+    let response = send_provider_request(&client, request)
+        .await
+        .expect("response");
+
+    assert_eq!(response.status, StatusCode::OK.as_u16());
+    assert_eq!(state.canonical_hits.load(Ordering::Relaxed), 1);
+}

--- a/sdk/gproxy-engine/src/engine.rs
+++ b/sdk/gproxy-engine/src/engine.rs
@@ -1042,7 +1042,8 @@ impl GproxyEngine {
             let mut meta = snapshot_request_meta(&http_request, credential_index);
 
             let response =
-                gproxy_channel::http_client::send_request(&self.client, http_request).await?;
+                gproxy_channel::http_client::send_provider_request(&self.client, http_request)
+                    .await?;
 
             if matches!(response.status, 401 | 403) {
                 tracing::warn!(
@@ -1063,9 +1064,11 @@ impl GproxyEngine {
                     let retry_start = std::time::Instant::now();
                     meta = snapshot_request_meta(&retry_request, credential_index);
 
-                    let retry_response =
-                        gproxy_channel::http_client::send_request(&self.client, retry_request)
-                            .await?;
+                    let retry_response = gproxy_channel::http_client::send_provider_request(
+                        &self.client,
+                        retry_request,
+                    )
+                    .await?;
                     fill_response_meta(&mut meta, &retry_response, retry_start);
                     return Ok((Some(retry_response), updates, Some(meta)));
                 }

--- a/sdk/gproxy-engine/src/store/runtime.rs
+++ b/sdk/gproxy-engine/src/store/runtime.rs
@@ -484,9 +484,9 @@ impl<C: Channel> ProviderRuntime for ProviderInstance<C> {
                     spoof_client,
                     forced_credential,
                 },
-                |c, req| {
+                move |c, req| {
                     let c = c.clone();
-                    async move { gproxy_channel::http_client::send_request(&c, req).await }
+                    async move { gproxy_channel::http_client::send_provider_request(&c, req).await }
                 },
             )
             .await;
@@ -539,9 +539,11 @@ impl<C: Channel> ProviderRuntime for ProviderInstance<C> {
                     spoof_client,
                     forced_credential,
                 },
-                |c, req| {
+                move |c, req| {
                     let c = c.clone();
-                    async move { gproxy_channel::http_client::send_request_stream(&c, req).await }
+                    async move {
+                        gproxy_channel::http_client::send_provider_request_stream(&c, req).await
+                    }
                 },
             )
             .await;


### PR DESCRIPTION
## Summary

Fix provider requests inheriting the engine's global redirect policy.

On shared reverse-proxy domains, that could silently follow a 3xx onto a different provider endpoint while gproxy still logged the original request URI, which looked like request-path stickiness when switching channels.

## Root Cause

The engine-wide `wreq::Client` enables redirect following for admin/update traffic such as GitHub release downloads.

Provider execution paths reused the same client behavior, so upstream/provider requests could also follow redirects even though retry metadata and logs were captured from the original `prepare_request` URI.

## Fix

- add a provider-specific send path in `sdk/gproxy-channel/src/http_client.rs`
- keep normal HTTP helpers using the existing redirect-following policy
- constrain provider redirects to conservative same-endpoint canonicalization only
- switch provider request, streaming request, and quota request paths to use the provider-specific send helper
- add regression coverage for:
  - blocking cross-endpoint redirects
  - allowing same-endpoint canonicalization redirects

## Testing

- `cargo fmt --all --check`

Full Rust test/build was not run locally in this environment.
