### PR TITLE
fix: drop deprecated output_format and avoid empty json_object schema in OpenAI→Claude transform

### DIFF
--- a/sdk/gproxy-protocol/src/transform/openai/generate_content/openai_chat_completions/claude/request.rs
+++ b/sdk/gproxy-protocol/src/transform/openai/generate_content/openai_chat_completions/claude/request.rs
@@ -300,11 +300,13 @@ impl TryFrom<OpenAiChatCompletionsRequest> for ClaudeCreateMessageRequest {
                         type_: ct::BetaJsonOutputFormatType::JsonSchema,
                     })
                 }
-                ot::ResponseTextFormatConfig::JsonObject(_) => Some(ct::BetaJsonOutputFormat {
-                    schema: serde_json::from_str::<ct::JsonObject>(r#"{"type":"object"}"#)
-                        .unwrap_or_default(),
-                    type_: ct::BetaJsonOutputFormatType::JsonSchema,
-                }),
+                // OpenAI's `json_object` means "valid JSON, no schema constraint". Anthropic's
+                // structured output always enforces a schema, and a permissive `{type:"object"}`
+                // schema is rejected on the claudecode tier (additionalProperties must be false,
+                // which then forbids all properties). Skip emitting output_config in this mode
+                // and let the caller's prompt instruct the model to return JSON. ST-BME and most
+                // OpenAI clients do exactly this.
+                ot::ResponseTextFormatConfig::JsonObject(_) => None,
                 ot::ResponseTextFormatConfig::Text(_) => None,
             });
 
@@ -488,7 +490,9 @@ impl TryFrom<OpenAiChatCompletionsRequest> for ClaudeCreateMessageRequest {
                 metadata,
                 cache_control: None,
                 output_config,
-                output_format,
+                // output_format is deprecated by Anthropic in favor of output_config.format.
+                // Sending both causes a 400 from the claudecode tier; emit only the new field.
+                output_format: None,
                 service_tier: claude_service_tier,
                 speed,
                 stop_sequences: chat_stop_to_vec(stop),

--- a/sdk/gproxy-protocol/src/transform/openai/generate_content/openai_chat_completions/claude/request.rs
+++ b/sdk/gproxy-protocol/src/transform/openai/generate_content/openai_chat_completions/claude/request.rs
@@ -295,8 +295,10 @@ impl TryFrom<OpenAiChatCompletionsRequest> for ClaudeCreateMessageRequest {
             .and_then(|text| text.format.as_ref())
             .and_then(|format| match format {
                 ot::ResponseTextFormatConfig::JsonSchema(schema) => {
+                    let mut coerced = schema.schema.clone();
+                    enforce_strict_object_schema(&mut coerced);
                     Some(ct::BetaJsonOutputFormat {
-                        schema: schema.schema.clone(),
+                        schema: coerced,
                         type_: ct::BetaJsonOutputFormatType::JsonSchema,
                     })
                 }
@@ -517,4 +519,45 @@ fn default_chat_thinking() -> ct::BetaThinkingConfigParam {
     ct::BetaThinkingConfigParam::Disabled(ct::BetaThinkingConfigDisabled {
         type_: ct::BetaThinkingConfigDisabledType::Disabled,
     })
+}
+
+/// Walk a JSON schema and force `additionalProperties: false` on every
+/// object-typed node. Anthropic's structured output rejects schemas where
+/// `additionalProperties` is `true` (or omitted, which it treats as true);
+/// OpenAI's strict mode requires the same, so coercing is consistent with
+/// both providers' contracts.
+fn enforce_strict_object_schema(schema: &mut ct::JsonObject) {
+    fn walk(value: &mut serde_json::Value) {
+        match value {
+            serde_json::Value::Object(map) => {
+                if matches!(map.get("type").and_then(|v| v.as_str()), Some("object")) {
+                    map.insert(
+                        "additionalProperties".to_string(),
+                        serde_json::Value::Bool(false),
+                    );
+                }
+                for v in map.values_mut() {
+                    walk(v);
+                }
+            }
+            serde_json::Value::Array(items) => {
+                for item in items {
+                    walk(item);
+                }
+            }
+            _ => {}
+        }
+    }
+
+    // Top-level schema is BTreeMap<String, Value>; if it is itself an
+    // object schema, set additionalProperties=false here too.
+    if matches!(schema.get("type").and_then(|v| v.as_str()), Some("object")) {
+        schema.insert(
+            "additionalProperties".to_string(),
+            serde_json::Value::Bool(false),
+        );
+    }
+    for v in schema.values_mut() {
+        walk(v);
+    }
 }


### PR DESCRIPTION
The OpenAI → Claude request transform produces requests that Anthropic's `/v1/messages` API rejects in three related ways. All three are addressed here.

### 1. Deprecated `output_format` (commit 1)

Anthropic deprecated this field in favor of `output_config.format`. The transform was setting both, so requests now get a 400:

> output_format: This field is deprecated. Use 'output_config.format' instead.

`output_format` is now always `None`; `output_config` carries the same info.

### 2. `json_object` collapses to empty `{}` (commit 1)

OpenAI's `response_format: { type: "json_object" }` was mapped to a `{"type":"object"}` schema. Anthropic now requires `additionalProperties: false` on object schemas, which then forbids any properties — so the model returns just `{}`.

OpenAI's `json_object` semantically means "valid JSON, no schema constraint" — there's no direct equivalent in Anthropic's structured output. The cleanest mapping is to skip emitting `output_config` in this mode and let the caller's prompt drive JSON formatting.

### 3. Schemas with `additionalProperties: true` are rejected (commit 2)

When a client sends `response_format: json_schema` whose schema either explicitly sets `additionalProperties: true` or omits it (which Anthropic treats as true), the request fails:

> output_config.format.schema: For 'object' type, 'additionalProperties: true' is not supported.

A small recursive walker now coerces `additionalProperties: false` on every object-typed node before forwarding. OpenAI's strict structured output mode requires the same constraint, so this is a no-op for clients that already produce strict schemas, and a fix for the rest.

## Verification

- `cargo test -p gproxy-protocol --lib --release` — 34 tests pass.
- End-to-end: OpenAI client sending `response_format: json_object` to a Claude upstream returns valid JSON content (e.g. `{"answer": 2}`) instead of `{}` or 400.
- End-to-end: a json_schema with `additionalProperties: true` and a nested object schema both round-trip correctly (`{"answer":2}` and `{"user":{"age":30,"name":"Alice"}}`).