### PR TITLE
fix(console): parse cache breakpoint ttl tags

### DIFF
--- a/RELEASE_NOTE.md
+++ b/RELEASE_NOTE.md
@@ -21,6 +21,7 @@
 - **Vertex CountToken/OpenAPI handling.** Vertex request body handling is stricter and OpenAPI chat-completions compatible requests route to the correct endpoint.
 - **Structured-output conversion cleanup.** OpenAI-to-Claude transforms drop deprecated `output_format`, avoid unsupported permissive JSON-object shims, and keep schema serialization strict.
 - **TOML export for rewrite rules.** Model alias/suffix rewrite rules no longer export empty filter dimensions as JSON null, avoiding `unsupported unit type` during config export (#94).
+- **Console cache-breakpoint TTL display.** The cache breakpoint editor now reads API-returned `ttl5m` / `ttl1h` values as `5m` / `1h` instead of rendering them as `auto` (#97).
 - **Responses/image stream schema tolerance.** Responses keepalive events and partial image-generation output items are accepted instead of turning valid upstream streams into local 500s.
 
 #### Changed
@@ -45,6 +46,7 @@
 - **Vertex CountToken / OpenAPI 处理.** Vertex 请求体处理更严格,OpenAPI chat-completions 兼容请求会路由到正确端点。
 - **结构化输出转换清理.** OpenAI → Claude 转换删除废弃的 `output_format`,避免生成上游不支持的宽松 JSON-object shim,并保持 schema 序列化严格。
 - **rewrite rules TOML 导出.** 模型别名 / 后缀变体自动生成的 rewrite rules 不再把空 filter 维度导出成 JSON null,避免配置导出时报 `unsupported unit type`(#94)。
+- **控制台缓存断点 TTL 显示修复.** cache breakpoint 编辑器现在会把 API 返回的 `ttl5m` / `ttl1h` 识别为 `5m` / `1h`,不再显示成 `auto`(#97)。
 - **Responses / image stream schema 兼容.** Responses keepalive 事件和 image-generation 的 partial output item 现在会被接受,不再把有效上游流误转成本地 500。
 
 #### 调整

--- a/frontend/console/src/modules/admin/providers/channel-constants.test.ts
+++ b/frontend/console/src/modules/admin/providers/channel-constants.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 
-import { parseBetaHeaders } from "./channel-constants";
+import { parseBetaHeaders, parseCacheBreakpoints } from "./channel-constants";
 
 describe("parseBetaHeaders", () => {
   it("parses JSON array strings", () => {
@@ -14,5 +14,19 @@ describe("parseBetaHeaders", () => {
     expect(parseBetaHeaders("prompt-caching-2024-07-31,files-api-2025-04-14")).toEqual([]);
     expect(parseBetaHeaders("not json")).toEqual([]);
     expect(parseBetaHeaders('{"beta":"prompt-caching-2024-07-31"}')).toEqual([]);
+  });
+});
+
+describe("parseCacheBreakpoints", () => {
+  it("normalizes API TTL tags back to console TTL values", () => {
+    expect(
+      parseCacheBreakpoints([
+        { target: "messages", position: "last_nth", index: 1, ttl: "ttl5m" },
+        { target: "system", position: "last_nth", index: 1, ttl: "ttl1h" },
+      ]),
+    ).toEqual([
+      { target: "messages", position: "last_nth", index: 1, ttl: "5m" },
+      { target: "system", position: "last_nth", index: 1, ttl: "1h" },
+    ]);
   });
 });

--- a/frontend/console/src/modules/admin/providers/channel-constants.ts
+++ b/frontend/console/src/modules/admin/providers/channel-constants.ts
@@ -56,8 +56,8 @@ function normalizePosition(value: unknown): CacheBreakpointPosition {
 function normalizeTtl(value: unknown): CacheBreakpointTtl {
   if (typeof value === "string") {
     const v = value.trim().toLowerCase();
-    if (v === "5m") return "5m";
-    if (v === "1h") return "1h";
+    if (v === "5m" || v === "ttl5m") return "5m";
+    if (v === "1h" || v === "ttl1h") return "1h";
   }
   return "auto";
 }


### PR DESCRIPTION
## Summary
- Normalize API-returned cache breakpoint TTL tags ttl5m/ttl1h for the console
- Add parser coverage for API TTL tag rendering
- Document the #97 fix in release notes

## Test Plan
- pnpm --dir frontend/console test -- src/modules/admin/providers/channel-constants.test.ts
- pnpm --dir frontend/console build

Fixes #97