### PR TITLE
chore(release): add release.sh + v2.0.0 notes

### DIFF
--- a/docs/release-notes/v2.0.0.md
+++ b/docs/release-notes/v2.0.0.md
@@ -1,0 +1,43 @@
+## v2.0.0
+
+> A full rewrite. The whole proxy is now a single Rust crate that builds the same engine for native, Docker, and the serverless edge (WebAssembly); an Operation-first protocol taxonomy replaces the old per-family transform tree, and existing v1 SQLite databases migrate in place on first boot.
+
+### English
+
+#### Added
+
+- **Three runtime form factors from one engine.** The same crate compiles to a native binary, a distroless Docker image, and a `wasm32` edge library. Edge wasm is live-verified on Cloudflare Workers, Netlify, Supabase, EdgeOne Pages, Deno Deploy, and Appwrite Functions; prebuilt one-click bundles ship on the `deploy` branch.
+- **Operation-first protocol taxonomy.** Capabilities are modeled as `Operation` / `OperationGroup` / `OperationKey` instead of per-provider-family buckets, with four content wire kinds (OpenAI Responses, OpenAI Chat Completions, Claude Messages, Gemini `generateContent`).
+- **Layered request pipeline.** Each request flows through classify → auth → preprocess → route → authz → balance → transform → process → channel → settle, with cross-protocol translation (OpenAI ↔ Claude ↔ Gemini) and a same-dialect minimal-parsing fast path.
+- **Multi-tenant control plane.** Users, API keys, glob model permissions, RPM/RPD/token rate limits, and USD quotas, plus Claude prompt caching, rewrite rules, and passive circuit breakers; a hot-path `ControlPlaneSnapshot` serves reads.
+- **Pluggable storage and cache.** SQLite / PostgreSQL / MySQL persistence with optional at-rest encryption; native memory/redis cache, or libSQL (Turso) / Upstash on the edge.
+- **Embedded React console** served at `/console`, baked into the binary.
+
+#### Changed
+
+- **Single-crate architecture.** v1's multi-crate / SDK layout (~110K lines, a 52K-line transform tree, several god files) is replaced by one `gproxy` crate (`lib.rs` + `main.rs` + responsibility-split modules).
+- **channel / transform / process are separate layers.** Channels only do upstream access (auth, endpoint, response classification); protocol conversion and provider rule-set rewrites each live in their own stage.
+
+#### Upgrading
+
+- Point a v2 binary at your existing v1 SQLite database and it migrates in place on first boot, backing the old file up as `*.v1.bak`. Configuration is by environment variable; live config then lives in the database and is managed through `/console`.
+
+### 简体中文
+
+#### 新增
+
+- **同源三形态.** 同一个 crate 编译出原生二进制、distroless Docker 镜像和 `wasm32` 边缘库。边缘 wasm 已在 Cloudflare Workers、Netlify、Supabase、EdgeOne Pages、Deno Deploy、Appwrite Functions 实测跑通;预构建一键产物放在 `deploy` 分支。
+- **Operation 优先的协议分类.** 协议能力按 `Operation` / `OperationGroup` / `OperationKey` 建模,而不是按 provider 家族分桶;内容生成有四种 wire kind(OpenAI Responses、OpenAI Chat Completions、Claude Messages、Gemini `generateContent`)。
+- **分层请求 pipeline.** 每个请求经过 classify → auth → preprocess → route → authz → balance → transform → process → channel → settle,支持跨协议转换(OpenAI ↔ Claude ↔ Gemini),同方言走极简解析快路径。
+- **多租户控制面.** 用户、API key、glob 模型权限、RPM/RPD/token 限速、USD 配额,以及 Claude 提示缓存、改写规则、被动熔断;热路径读 `ControlPlaneSnapshot` 快照。
+- **可插拔存储与缓存.** SQLite / PostgreSQL / MySQL 持久化,可选静态加密;native 用 memory/redis,边缘用 libSQL(Turso)/ Upstash。
+- **内置 React 控制台**,路径 `/console`,直接嵌进二进制。
+
+#### 调整
+
+- **单 crate 架构.** v1 的多 crate / SDK 结构(约 11 万行,5.2 万行的转换树,若干上帝文件)替换为单个 `gproxy` crate(`lib.rs` + `main.rs` + 职责拆分模块)。
+- **channel / transform / process 三层分离.** channel 只负责上游访问(auth、endpoint、响应分类),协议转换和 provider 规则改写各自独立成阶段。
+
+#### 升级
+
+- 把 v2 二进制指向现有 v1 SQLite 库,首次启动会就地迁移(旧库备份为 `*.v1.bak`)。配置走环境变量,运行期配置进数据库,通过 `/console` 管理。

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -1,0 +1,121 @@
+#!/usr/bin/env bash
+# Cut a gproxy release.
+#
+# Publishes a GitHub Release whose `release: published` event drives
+# .github/workflows/release.yml — which builds the native binaries, edge wasm
+# bundles, and multi-arch Docker images, attaches the assets, and force-refreshes
+# the `deploy` branch. This script only validates, tags, and publishes; CI does
+# all the building.
+#
+# Usage:
+#   scripts/release.sh [-v VERSION] [-n NOTES_FILE] [--draft] [--dry-run] [-y]
+#
+#   -v VERSION     Release version (default: the `version` in Cargo.toml).
+#                  Tag is `v$VERSION`, release title `gproxy v$VERSION`.
+#   -n NOTES_FILE  Bilingual release notes (default: docs/release-notes/v$VERSION.md).
+#                  Same shape as previous releases: a `## vX.Y.Z` heading, a `>`
+#                  summary, then `### English` / `### 简体中文` with
+#                  `#### Added` / `#### Fixed` / `#### Changed` sections.
+#   --draft        Create a draft release. NOTE: a draft does NOT fire the
+#                  release workflow — publish it later to trigger the build.
+#   --dry-run      Print what would happen; create nothing.
+#   -y             Skip the confirmation prompt.
+#
+# To fix the notes on an ALREADY-published release, don't re-run this — use:
+#   gh release edit vX.Y.Z --notes-file docs/release-notes/vX.Y.Z.md
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT"
+
+VERSION=""
+NOTES=""
+DRAFT=0
+DRY=0
+YES=0
+TARGET="main"
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    -v) VERSION="$2"; shift 2 ;;
+    -n) NOTES="$2"; shift 2 ;;
+    --draft)   DRAFT=1; shift ;;
+    --dry-run) DRY=1; shift ;;
+    -y)        YES=1; shift ;;
+    -h|--help) sed -n '2,28p' "$0"; exit 0 ;;
+    *) echo "release.sh: unknown arg: $1" >&2; exit 2 ;;
+  esac
+done
+
+die() { echo "release.sh: $*" >&2; exit 1; }
+
+# --- Preconditions ----------------------------------------------------------
+command -v gh  >/dev/null 2>&1 || die "the GitHub CLI (gh) is required"
+command -v git >/dev/null 2>&1 || die "git is required"
+[ -f Cargo.toml ] || die "must run from the crate root (no Cargo.toml at $ROOT)"
+gh auth status >/dev/null 2>&1 || die "gh is not authenticated (run: gh auth login)"
+
+# Version: explicit, else the crate version from Cargo.toml.
+if [ -z "$VERSION" ]; then
+  VERSION="$(grep -m1 '^version' Cargo.toml | sed -E 's/.*"([^"]+)".*/\1/')"
+  [ -n "$VERSION" ] || die "could not read version from Cargo.toml; pass -v"
+fi
+TAG="v$VERSION"
+
+# Notes: explicit, else the per-version file under docs/release-notes/.
+[ -n "$NOTES" ] || NOTES="docs/release-notes/$TAG.md"
+[ -f "$NOTES" ] || die "release notes not found: $NOTES (create it, same format as past releases)"
+[ -s "$NOTES" ] || die "release notes file is empty: $NOTES"
+
+# The tag must not already exist (locally or on origin).
+git rev-parse -q --verify "refs/tags/$TAG" >/dev/null 2>&1 && die "tag $TAG already exists locally"
+if git ls-remote --exit-code --tags origin "$TAG" >/dev/null 2>&1; then
+  die "tag $TAG already exists on origin"
+fi
+
+# The release builds from $TARGET; warn if the working tree looks stale.
+git fetch -q origin "$TARGET" 2>/dev/null || true
+if ! git rev-parse --verify -q "origin/$TARGET" >/dev/null 2>&1; then
+  die "origin/$TARGET not found"
+fi
+
+# --- Plan -------------------------------------------------------------------
+echo "release.sh plan"
+echo "  tag      : $TAG"
+echo "  title    : gproxy $TAG"
+echo "  target   : $TARGET ($(git rev-parse --short "origin/$TARGET"))"
+echo "  notes    : $NOTES"
+echo "  draft    : $([ "$DRAFT" = 1 ] && echo yes || echo 'no (publishing fires release.yml)')"
+echo
+
+if [ "$DRY" = 1 ]; then
+  echo "[dry-run] would run:"
+  echo "  gh release create $TAG --target $TARGET --title \"gproxy $TAG\" \\"
+  echo "    $([ "$DRAFT" = 1 ] && echo --draft || echo --latest) --notes-file $NOTES"
+  exit 0
+fi
+
+if [ "$YES" != 1 ]; then
+  printf "Publish %s now? [y/N] " "$TAG"
+  read -r ans
+  case "$ans" in y|Y|yes|YES) ;; *) echo "aborted."; exit 1 ;; esac
+fi
+
+# --- Publish ----------------------------------------------------------------
+create_args=(release create "$TAG" --target "$TARGET" --title "gproxy $TAG" --notes-file "$NOTES")
+if [ "$DRAFT" = 1 ]; then
+  create_args+=(--draft)
+else
+  create_args+=(--latest)
+fi
+
+gh "${create_args[@]}"
+
+echo
+if [ "$DRAFT" = 1 ]; then
+  echo "Draft $TAG created (no build yet). Publish it to trigger release.yml:"
+  echo "  gh release edit $TAG --draft=false"
+else
+  echo "Published $TAG. The release workflow is now building:"
+  echo "  gh run list --workflow=release.yml --limit 3"
+fi


### PR DESCRIPTION
Adds `scripts/release.sh` (validates → tags → publishes a GitHub Release that drives `release.yml`) and `docs/release-notes/v2.0.0.md` (bilingual changelog, same format as the v1.0.x releases). The live v2.0.0 release notes were already updated to this content via `gh release edit`.