### PR TITLE
fix: support Postgres schema migration version reads

### DIFF
--- a/src/pipeline/failover/attempt.rs
+++ b/src/pipeline/failover/attempt.rs
@@ -350,6 +350,7 @@ pub(super) struct ResponseRuleCtx<'a> {
 /// `upstream` is `Some`, the post-decode provider response is captured for
 /// §8-D logging (buffered: returned via `upstream_raw`; streaming: backfilled by
 /// the spliced guard).
+#[allow(clippy::too_many_arguments)]
 pub(super) fn materialize(
     channel: &Arc<dyn Channel>,
     source: BodySource,

--- a/src/store/persistence/db/schema.rs
+++ b/src/store/persistence/db/schema.rs
@@ -5,7 +5,7 @@
 use sea_orm::{ConnectionTrait, DatabaseConnection, EntityTrait, Schema, Statement};
 
 use crate::store::persistence::migrations::{
-    CREATE_MIGRATIONS_TABLE, MigrationDialect, SELECT_MAX_VERSION, latest_version, pending,
+    CREATE_MIGRATIONS_TABLE, MigrationDialect, latest_version, pending, select_max_version_sql,
 };
 
 use super::entities::authz::{quota, rate_limit, route_permission};
@@ -164,7 +164,10 @@ pub(super) async fn run_migrations(conn: &DatabaseConnection) -> anyhow::Result<
     conn.execute_unprepared(CREATE_MIGRATIONS_TABLE).await?;
 
     let current = conn
-        .query_one_raw(Statement::from_string(backend, SELECT_MAX_VERSION))
+        .query_one_raw(Statement::from_string(
+            backend,
+            select_max_version_sql(dialect),
+        ))
         .await?
         .map(|row| row.try_get::<i64>("", "v"))
         .transpose()?

--- a/src/store/persistence/migrations.rs
+++ b/src/store/persistence/migrations.rs
@@ -5,7 +5,7 @@
 //!
 //! ## Model
 //!
-//! A `schema_migrations(version INTEGER PRIMARY KEY, applied_at INTEGER)` table
+//! A `schema_migrations(version BIGINT PRIMARY KEY, applied_at BIGINT)` table
 //! tracks which migrations have been applied. On connect each SQL backend:
 //!
 //!   1. runs its existing `CREATE TABLE IF NOT EXISTS` baseline (entity-driven
@@ -100,14 +100,27 @@ impl Migration {
     }
 }
 
-/// Portable DDL for the bookkeeping table. `INTEGER` is accepted by all three
-/// dialects; no autoincrement needed (the version is supplied explicitly).
+/// Portable DDL for the bookkeeping table. `BIGINT` matches the Rust `i64`
+/// migration metadata; no autoincrement needed (the version is supplied
+/// explicitly).
 pub const CREATE_MIGRATIONS_TABLE: &str = "CREATE TABLE IF NOT EXISTS schema_migrations (\
-     version INTEGER PRIMARY KEY, \
-     applied_at INTEGER NOT NULL)";
+     version BIGINT PRIMARY KEY, \
+     applied_at BIGINT NOT NULL)";
 
 /// Highest applied version, reading the bookkeeping table.
 pub const SELECT_MAX_VERSION: &str = "SELECT COALESCE(MAX(version), 0) AS v FROM schema_migrations";
+
+/// Dialect-specific version read. PostgreSQL reports legacy `INTEGER`
+/// migration tables as `INT4`, and sqlx will not decode that into `i64`
+/// unless the result expression is explicitly widened.
+pub fn select_max_version_sql(dialect: MigrationDialect) -> &'static str {
+    match dialect {
+        MigrationDialect::Postgres => {
+            "SELECT CAST(COALESCE(MAX(version), 0) AS BIGINT) AS v FROM schema_migrations"
+        }
+        MigrationDialect::Sqlite | MigrationDialect::MySql => SELECT_MAX_VERSION,
+    }
+}
 
 /// Ordered list of migrations to apply *after* the baseline. Append new
 /// entries here (see the module docs).
@@ -258,5 +271,21 @@ mod tests {
             .unwrap_or(BASELINE_VERSION);
         assert_eq!(latest_version(), top);
         assert!(pending(latest_version()).is_empty());
+    }
+
+    #[test]
+    fn postgres_max_version_query_widens_legacy_integer_tables() {
+        assert_eq!(
+            select_max_version_sql(MigrationDialect::Postgres),
+            "SELECT CAST(COALESCE(MAX(version), 0) AS BIGINT) AS v FROM schema_migrations"
+        );
+        assert_eq!(
+            select_max_version_sql(MigrationDialect::Sqlite),
+            SELECT_MAX_VERSION
+        );
+        assert_eq!(
+            select_max_version_sql(MigrationDialect::MySql),
+            SELECT_MAX_VERSION
+        );
     }
 }


### PR DESCRIPTION
## Summary
- widen the schema_migrations bookkeeping table to BIGINT for new databases
- cast Postgres MAX(version) reads to BIGINT so existing INTEGER migration tables decode as i64
- keep SQLite/MySQL using the existing portable version query
- add a local clippy allow matching the existing failover helper style so the current Backend CI passes on stable

Fixes #109

## Validation
- cargo fmt --check
- cargo fmt --all --check
- cargo clippy --features full --all-targets -- -D warnings
- cargo test store::persistence::migrations::tests
- cargo test connect_stamps_latest_and_leaves_nothing_pending