### PR TITLE
fix(ci): make pnpm workspace explicit

### DIFF
--- a/console/pnpm-workspace.yaml
+++ b/console/pnpm-workspace.yaml
@@ -1,2 +1,3 @@
 # Marks console/ as its own pnpm workspace root so pnpm never traverses up to
 # the v1 repo's workspace at /home/linhuan/gproxy (which would pollute it).
+packages: []


### PR DESCRIPTION
## Summary
- define an explicit empty package list for the console pnpm workspace
- avoid Dependabot's comment-only workspace parser crash while preserving the root-only workspace

## Validation
- pnpm list --depth -1
- cargo fmt --all --check
- cargo clippy --features full --all-targets -- -D warnings