### PR TITLE
Release v2.1.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1797,7 +1797,7 @@ dependencies = [
 
 [[package]]
 name = "gproxy"
-version = "2.0.20"
+version = "2.1.0"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -1854,7 +1854,7 @@ dependencies = [
 
 [[package]]
 name = "gproxy-protocol"
-version = "2.0.20"
+version = "2.1.0"
 dependencies = [
  "http",
  "serde",
@@ -1863,7 +1863,7 @@ dependencies = [
 
 [[package]]
 name = "gproxy-tokenize"
-version = "2.0.20"
+version = "2.1.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1879,7 +1879,7 @@ dependencies = [
 
 [[package]]
 name = "gproxy-transform"
-version = "2.0.20"
+version = "2.1.0"
 dependencies = [
  "blake3",
  "bytes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gproxy"
-version = "2.0.20"
+version = "2.1.0"
 edition = "2024"
 license = "AGPL-3.0-or-later"
 description = "GPROXY v2 — high-performance LLM proxy (rewrite)"
@@ -34,9 +34,9 @@ bytes = "1"
 chacha20poly1305 = "0.11.0"
 futures-core = "0.3"
 futures-util = "0.3"
-gproxy-protocol = { path = "crates/gproxy-protocol", version = "2.0.20" }
-gproxy-tokenize = { path = "crates/gproxy-tokenize", version = "2.0.20" }
-gproxy-transform = { path = "crates/gproxy-transform", version = "2.0.20" }
+gproxy-protocol = { path = "crates/gproxy-protocol", version = "2.1.0" }
+gproxy-tokenize = { path = "crates/gproxy-tokenize", version = "2.1.0" }
+gproxy-transform = { path = "crates/gproxy-transform", version = "2.1.0" }
 # Single RNG source for DEK/nonce/PKCE/ids across native + wasm. Native uses the
 # default OS backend; wasm enables the `wasm_js` backend (see the wasm target table).
 getrandom = "0.4"
@@ -64,7 +64,7 @@ tower-http = { version = "0.7", features = ["cors"] }
 clap = { version = "4", features = ["derive", "env"] }
 redis = { version = "1", features = ["tokio-comp", "connection-manager"], optional = true }
 sea-orm = { version = "2.0.0-rc.42", features = ["runtime-tokio-rustls", "sqlx-sqlite", "sqlx-postgres", "sqlx-mysql"], optional = true }
-# MIGRATE-V1 (remove in 2.1): read-only reader for the legacy v1 SQLite DB during
+# MIGRATE-V1 (temporary 2.x bridge): read-only reader for the legacy v1 SQLite DB during
 # the one-shot v1→v2 startup migration. Only the `sqlite` driver is needed; the
 # write path goes through the normal `persist-db` backend.
 sqlx = { version = "0.9", default-features = false, features = ["runtime-tokio", "tls-rustls-ring", "sqlite"], optional = true }
@@ -121,7 +121,7 @@ cache-memory = []
 cache-redis = ["dep:redis"]
 # persistence backend (native)
 persist-db = ["dep:sea-orm"]
-# MIGRATE-V1 (remove in 2.1): one-shot v1→v2 startup data migration. Pulls the
+# MIGRATE-V1 (temporary 2.x bridge): one-shot v1→v2 startup data migration. Pulls the
 # read-only sqlx sqlite reader; the write path reuses `persist-db`. Shipped in the
 # default/full feature sets so a v2 binary dropped in place auto-migrates v1 data.
 migrate-v1 = ["dep:sqlx", "persist-db"]

--- a/crates/gproxy-protocol/Cargo.toml
+++ b/crates/gproxy-protocol/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gproxy-protocol"
-version = "2.0.20"
+version = "2.1.0"
 edition = "2024"
 authors = ["LeenHawk <leenhawk@leenhawk.com>"]
 license = "MIT"

--- a/crates/gproxy-tokenize/Cargo.toml
+++ b/crates/gproxy-tokenize/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gproxy-tokenize"
-version = "2.0.20"
+version = "2.1.0"
 edition = "2024"
 license = "AGPL-3.0-or-later"
 description = "GPROXY local token counting"

--- a/crates/gproxy-transform/Cargo.toml
+++ b/crates/gproxy-transform/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gproxy-transform"
-version = "2.0.20"
+version = "2.1.0"
 edition = "2024"
 license = "AGPL-3.0-or-later"
 description = "GPROXY provider protocol transforms"
@@ -8,7 +8,7 @@ description = "GPROXY provider protocol transforms"
 [dependencies]
 blake3 = "1"
 bytes = "1"
-gproxy-protocol = { path = "../gproxy-protocol", version = "2.0.20" }
+gproxy-protocol = { path = "../gproxy-protocol", version = "2.1.0" }
 http = "1"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"

--- a/docs/release-notes/v2.1.0.md
+++ b/docs/release-notes/v2.1.0.md
@@ -1,0 +1,51 @@
+## v2.1.0
+
+> Adds exact per-operation provider endpoints, client compatibility presets, richer observability, model-scoped health, and merged credential model catalogues, while consolidating persistence and runtime architecture for the 2.1 line.
+
+### English
+
+#### Added
+
+- **Exact provider endpoint overrides.** Providers can set a final URL for each routed operation while retaining `base_url` as the fallback prefix. Exact endpoints take precedence, receive no appended path, preserve configured query parameters, and support `{model}` placeholders for dynamic model paths. The Console provides responsive endpoint cards with unique operation types and URL validation.
+- **Client compatibility presets.** Provider rule sets now include one-click presets for OpenCode, pi-mono, Aider, Cline, Continue, and Cursor. OpenCode presets also apply paired request and response transformations for tool and MCP naming compatibility.
+- **Expanded observability.** Usage summaries now include filtered request, token, cache-write, cache-read, and cost totals. Request logs support time, provider, user, and route filters, while usage, request-log, portal, and audit views use server-side pagination. Captured headers and bodies include copy actions.
+- **Model-scoped credential health.** Failures can cool down the exact credential/model pair without unnecessarily disabling unrelated models on the same credential. Health state is persisted per final upstream model.
+- **Merged model catalogues.** Model discovery queries all enabled and available credentials, unions successful catalogues, and deduplicates models instead of accepting only one credential's response.
+- **Variant source selection.** OpenRouter and Vercel model variant presets can select their upstream source directly in the Console.
+
+#### Fixed
+
+- **Structured rule defaults.** Structured rule configuration now materializes complete defaults instead of silently saving partial configuration.
+- **Android loopback Console access.** Android packages permit the launcher's local HTTP health check and Console access.
+- **Release target reliability.** Unsupported experimental UPX packing is disabled for Linux RISC-V and Windows ARM64 artifacts, while the remaining release targets keep their established packaging path.
+
+#### Changed
+
+- **Database-only persistence.** Native and Docker deployments now use SQLite, PostgreSQL, or MySQL database persistence. The legacy file persistence backend has been removed. Before upgrading a file-backed deployment, use v2.0.20 to run `gproxy export --out backup.json`, protect the plaintext-secret bundle, configure a database backend in v2.1.0, then run `gproxy import --in backup.json`.
+- **v1 migration bridge retained.** The automatic and explicit v1 SQLite migrator remains available in v2.1.0 to avoid stranding older installations. It is transitional and will be removed in a later 2.x release.
+- **Self-update cleanup.** Successful self-updates no longer retain persistent `<executable>.prev` rollback copies; temporary swap backups are removed after a successful replacement, and stale legacy copies are cleaned up.
+- **Architecture and maintenance.** Protocol, transform, channel, HTTP, pipeline, and persistence boundaries were consolidated; SeaORM reached 2.0.0, dependencies were refreshed, and CodeQL and Dependabot automation were added.
+
+### 简体中文
+
+#### 新增
+
+- **Provider 精确 Endpoint 覆盖。** Provider 现在可以按路由操作设置最终 URL，同时保留 `base_url` 作为回退前缀。精确 Endpoint 优先级更高，不会追加路径，会保留已配置的查询参数，并支持在动态模型路径中使用 `{model}` 占位符。Console 提供响应式 Endpoint 卡片、唯一操作类型选择和 URL 校验。
+- **客户端兼容预设。** Provider Rule Set 新增 OpenCode、pi-mono、Aider、Cline、Continue 和 Cursor 一键预设。OpenCode 预设还会成对处理请求与响应中的 Tool 和 MCP 名称兼容转换。
+- **增强可观测性。** Usage Summary 现在支持按筛选条件统计请求数、Token、缓存写入、缓存读取与费用。请求日志支持时间、Provider、用户和路由筛选；Usage、请求日志、Portal 和 Audit 页面改用服务端分页；捕获的 Header 与 Body 可直接复制。
+- **模型级 Credential 健康状态。** 故障可以只冷却精确的 Credential/Model 组合，不再无谓影响同一 Credential 上的其它模型；健康状态会按最终上游模型持久化。
+- **合并模型目录。** 模型发现会查询所有已启用且可用的 Credential，合并成功返回的目录并去重，不再只采用单个 Credential 的响应。
+- **Variant 上游来源选择。** OpenRouter 和 Vercel 的模型 Variant 预设现在可在 Console 中直接选择上游来源。
+
+#### 修复
+
+- **结构化规则默认值。** 结构化规则配置现在会完整写入默认值，不再静默保存不完整配置。
+- **Android 本地 Console 访问。** Android 安装包允许启动器进行本地 HTTP 健康检查并访问 Console。
+- **Release 目标可靠性。** Linux RISC-V 与 Windows ARM64 产物已关闭不受支持的实验性 UPX 压缩，其余发布目标继续使用稳定的打包路径。
+
+#### 调整
+
+- **仅保留数据库持久化。** Native 与 Docker 部署现在使用 SQLite、PostgreSQL 或 MySQL，旧文件持久化后端已移除。文件持久化部署升级前，请先使用 v2.0.20 执行 `gproxy export --out backup.json`，妥善保护包含明文密钥的 Bundle；在 v2.1.0 配置数据库后，再执行 `gproxy import --in backup.json`。
+- **继续保留 v1 迁移桥接。** v2.1.0 仍提供自动和显式 v1 SQLite 迁移能力，避免旧安装无法直接升级。该能力仍属过渡方案，将在后续 2.x 版本移除。
+- **Self-update 清理。** 自更新成功后不再长期保留 `<可执行文件>.prev` 回滚副本；临时交换备份会在替换成功后删除，旧版遗留副本也会被清理。
+- **架构与维护。** Protocol、Transform、Channel、HTTP、Pipeline 和 Persistence 边界已收敛；SeaORM 升级至 2.0.0，依赖同步刷新，并新增 CodeQL 与 Dependabot 自动化。

--- a/docs/src/content/docs/deployment/release-build.md
+++ b/docs/src/content/docs/deployment/release-build.md
@@ -103,8 +103,8 @@ shasum -a 256 gproxy-local.zip > gproxy-local.zip.sha256
 The release workflow may UPX-compress selected Linux, Android, and Windows
 artifacts before packaging. It signs macOS artifacts ad hoc with
 `codesign --sign -`. Android APKs are signed with the configured release
-keystore when `ANDROID_SIGNING_KEYSTORE_B64` is available to CI; otherwise the
-workflow falls back to an ephemeral debug key.
+keystore. Tagged release builds require the configured signing secrets; local
+or non-release packaging may fall back to an ephemeral debug key.
 
 ## First Run
 

--- a/docs/src/content/docs/deployment/v1-to-v2.md
+++ b/docs/src/content/docs/deployment/v1-to-v2.md
@@ -8,9 +8,9 @@ replace the binary and start directly. On startup, v2 can detect an old
 `data/gproxy.db`, read the v1 control-plane configuration, create a new v2
 database, and move the old database aside as a backup.
 
-This migrator is transitional and is planned for removal in 2.1. Move v1
-instances through a v2 build that still includes the default `migrate-v1`
-feature before upgrading to later v2 releases.
+This migrator is transitional but remains available in 2.1. Move v1 instances
+through a v2 build that includes the default `migrate-v1` feature before it is
+removed in a later 2.x release.
 
 ## When Automatic Migration Runs
 

--- a/docs/src/content/docs/zh-cn/deployment/v1-to-v2.md
+++ b/docs/src/content/docs/zh-cn/deployment/v1-to-v2.md
@@ -6,8 +6,8 @@ description: 将 v1 SQLite 部署迁移到 GPROXY v2，并理解行为差异。
 v2 带有一个临时 v1 SQLite 迁移器，使常见单机部署可以替换二进制后直接启动。启动时，
 v2 可识别旧的 `data/gproxy.db`，读取 v1 控制面配置，创建新的 v2 数据库，并把旧库移动为备份。
 
-这个迁移器是过渡能力，计划在 2.1 移除。仍在 v1 的实例应先经过仍包含默认
-`migrate-v1` feature 的 v2 build 完成迁移，再升级到后续 v2 release。
+这个迁移器是过渡能力，但在 2.1 中仍然保留。仍在 v1 的实例应先经过包含默认
+`migrate-v1` feature 的 v2 build 完成迁移；该能力将在后续 2.x release 中移除。
 
 ## 自动迁移何时触发
 

--- a/src/app/migrate_v1/cipher.rs
+++ b/src/app/migrate_v1/cipher.rs
@@ -1,4 +1,4 @@
-//! MIGRATE-V1 (remove in 2.1): decrypt secrets stored by the legacy v1 backend.
+//! MIGRATE-V1 (temporary 2.x bridge): decrypt legacy v1 secrets.
 //!
 //! v1 (`crates/gproxy-storage/src/seaorm/crypto.rs`) sealed `credentials.secret_json`
 //! and `user_keys.api_key_ciphertext` with XChaCha20-Poly1305 under an Argon2id

--- a/src/app/migrate_v1/map.rs
+++ b/src/app/migrate_v1/map.rs
@@ -1,4 +1,4 @@
-//! MIGRATE-V1 (remove in 2.1): map v1 rows into a v2 `import::Bundle`.
+//! MIGRATE-V1 (temporary 2.x bridge): map v1 rows into a v2 `import::Bundle`.
 //!
 //! The bundle carries PLAINTEXT secrets (v1-decrypted); `import_bundle` re-seals
 //! them under the v2 master key. `routing_rules` are NOT mapped here — the v1

--- a/src/app/migrate_v1/mod.rs
+++ b/src/app/migrate_v1/mod.rs
@@ -1,4 +1,4 @@
-//! MIGRATE-V1 (remove in 2.1): one-shot legacy v1 → v2 data migration.
+//! MIGRATE-V1 (temporary 2.x bridge): one-shot legacy v1 → v2 data migration.
 //!
 //! Two entry points, one core:
 //! - [`maybe_migrate_on_boot`] runs on startup *before* the persistence backend

--- a/src/app/migrate_v1/read.rs
+++ b/src/app/migrate_v1/read.rs
@@ -1,4 +1,4 @@
-//! MIGRATE-V1 (remove in 2.1): read the legacy v1 SQLite database (read-only)
+//! MIGRATE-V1 (temporary 2.x bridge): read the legacy v1 SQLite database (read-only)
 //! into plain row structs. Only the control-plane config tables are read; usage,
 //! request logs, files and ephemeral health are intentionally skipped (§ design).
 

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -5,7 +5,7 @@ pub mod export;
 pub mod import;
 pub mod install_setup;
 pub mod invalidation;
-// MIGRATE-V1 (remove in 2.1): one-shot legacy v1→v2 data migration.
+// MIGRATE-V1 (temporary 2.x bridge): one-shot legacy v1→v2 data migration.
 #[cfg(feature = "migrate-v1")]
 pub mod migrate_v1;
 pub mod models_index;

--- a/src/main/bootstrap.rs
+++ b/src/main/bootstrap.rs
@@ -29,7 +29,7 @@ pub(crate) async fn run(cli: Cli) -> anyhow::Result<()> {
         .await;
     }
 
-    // MIGRATE-V1 (remove in 2.1): explicit migration subcommand — self-contained
+    // MIGRATE-V1 (temporary 2.x bridge): explicit migration subcommand — self-contained
     // and dispatched before the shared persistence is built (it manages its own
     // source/target db connections).
     #[cfg(feature = "migrate-v1")]
@@ -97,7 +97,7 @@ pub(crate) async fn run(cli: Cli) -> anyhow::Result<()> {
     }
     let cipher = gproxy::crypto::cipher_from_master_key(master_key.as_deref())?;
 
-    // MIGRATE-V1 (remove in 2.1): on the serve path, if the configured SQLite db
+    // MIGRATE-V1 (temporary 2.x bridge): on the serve path, if the configured SQLite db
     // is a legacy v1 database, migrate it to v2 in place (backing the v1 file up)
     // BEFORE the v2 backend opens it. No-op on a fresh install or an existing v2.
     #[cfg(feature = "migrate-v1")]

--- a/src/main/cli.rs
+++ b/src/main/cli.rs
@@ -125,7 +125,7 @@ pub(crate) enum Command {
         #[arg(long = "out")]
         output: PathBuf,
     },
-    /// MIGRATE-V1 (remove in 2.1): import a legacy v1 SQLite database into a v2
+    /// MIGRATE-V1 (temporary 2.x bridge): import a legacy v1 SQLite database into a v2
     /// db backend, then exit. For explicit/offline migrations; the serve path
     /// auto-migrates a v1 db found at the configured location.
     #[cfg(feature = "migrate-v1")]

--- a/src/store/persistence/db.rs
+++ b/src/store/persistence/db.rs
@@ -32,7 +32,7 @@ impl DbPersistence {
     }
 
     /// Close the underlying connection pool, flushing and releasing the SQLite
-    /// file handle. MIGRATE-V1 (remove in 2.1): the v1→v2 migration builds a
+    /// file handle. MIGRATE-V1 (temporary 2.x bridge): the v1→v2 migration builds a
     /// throwaway db here, imports into it, then must close it before renaming the
     /// file into place — an open WAL pool would otherwise hold the file.
     pub async fn close(self) -> anyhow::Result<()> {


### PR DESCRIPTION
## Summary
- bump all workspace crates to 2.1.0
- add bilingual v2.1.0 release notes and upgrade guidance
- retain the v1 migration bridge for a later 2.x removal and document release signing requirements

## Verification
- cargo fmt --all --check
- cargo clippy --features full --all-targets -- -D warnings
- cargo test --features full
- cargo check --lib --no-default-features --features edge --target wasm32-unknown-unknown
- pnpm --dir console test --run
- pnpm --dir console run typecheck
- pnpm --dir console run check:i18n
- pnpm --dir console run build
- pnpm --dir docs run build
- scripts/release.sh -v 2.1.0 -n docs/release-notes/v2.1.0.md --dry-run