### PR TITLE
fix(chatgpt): finalize unterminated SSE streams

### DIFF
--- a/src/channel/bulletins/chatgpt/images.rs
+++ b/src/channel/bulletins/chatgpt/images.rs
@@ -33,6 +33,7 @@ pub(super) struct ImagePointer {
 pub(super) fn extract_image_pointers(body: &[u8]) -> (Vec<ImagePointer>, Option<String>) {
     let mut decoder = SseDecoder::new();
     decoder.feed(body);
+    decoder.finish();
 
     let mut conversation_id: Option<String> = None;
     let mut ids: Vec<String> = Vec::new();

--- a/src/channel/bulletins/chatgpt/images.rs
+++ b/src/channel/bulletins/chatgpt/images.rs
@@ -291,4 +291,14 @@ data: {"p":"","o":"add","v":{"message":{"content":{"content_type":"multimodal_te
         assert_eq!(ptrs.len(), 1);
         assert_eq!(ptrs[0].id, "sed:sedfoo_bar");
     }
+
+    #[test]
+    fn extracts_pointer_from_unterminated_final_event() {
+        let body = br#"event: delta
+data: {"p":"","o":"add","v":{"message":{"content":{"content_type":"multimodal_text","parts":[{"asset_pointer":"file-service://file_eof"}]},"author":{"role":"assistant"}},"conversation_id":"conv-eof"},"c":0}"#;
+        let (ptrs, cid) = extract_image_pointers(body);
+        assert_eq!(cid.as_deref(), Some("conv-eof"));
+        assert_eq!(ptrs.len(), 1);
+        assert_eq!(ptrs[0].id, "file_eof");
+    }
 }

--- a/src/channel/bulletins/chatgpt/mod.rs
+++ b/src/channel/bulletins/chatgpt/mod.rs
@@ -357,6 +357,7 @@ impl ChannelStreamDecoder for ChatGptStreamDecoder {
 
     fn finish(&mut self) -> Vec<u8> {
         let mut out = Vec::new();
+        self.decoder.finish();
         self.drain_events(&mut out);
         // Synthesize a stop if the upstream never sent `finished_successfully`.
         if !self.converter.finished() && self.converter.emitted_role() {

--- a/src/channel/bulletins/chatgpt/mod.rs
+++ b/src/channel/bulletins/chatgpt/mod.rs
@@ -484,3 +484,62 @@ async fn chat_via_conduit(
         None => Ok(one_chunk(http::StatusCode::OK, sse_headers(), stub)),
     }
 }
+
+#[cfg(test)]
+mod stream_tests {
+    use super::*;
+    use crate::http::client::{ClientError, RespStream};
+    use futures_util::StreamExt;
+
+    #[tokio::test]
+    async fn production_stream_finishes_unterminated_multibyte_event() {
+        let body = concat!(
+            "event: delta\n",
+            "data: {\"p\":\"\",\"o\":\"add\",\"v\":{\"message\":{\"id\":\"asst\",\"author\":{\"role\":\"assistant\"},\"content\":{\"content_type\":\"text\",\"parts\":[\"\"]},\"status\":\"in_progress\",\"metadata\":{\"model_slug\":\"gpt-5\"}},\"conversation_id\":\"c1\"},\"c\":0}\n\n",
+            "event: delta\n",
+            "data: {\"v\":[{\"p\":\"/message/content/parts/0\",\"o\":\"append\",\"v\":\"A\"}]}\n\n",
+            "event: delta\n",
+            "data: {\"v\":[{\"p\":\"/message/content/parts/0\",\"o\":\"append\",\"v\":\"汉字🚀\"}]}\r\n",
+        );
+        let rocket = "🚀".as_bytes();
+        let rocket_start = body
+            .as_bytes()
+            .windows(rocket.len())
+            .position(|window| window == rocket)
+            .unwrap();
+        let split = rocket_start + 1;
+        let chunks: Vec<Result<Bytes, ClientError>> = vec![
+            Ok(Bytes::copy_from_slice(&body.as_bytes()[..split])),
+            Ok(Bytes::copy_from_slice(&body.as_bytes()[split..])),
+        ];
+        let source: RespStream = Box::pin(futures_util::stream::iter(chunks));
+        let decoder = <ChatGptChannel as Channel>::stream_decoder(&ChatGptChannel).unwrap();
+        let output: Vec<Bytes> = crate::pipeline::stream::channel_decode_stream(source, decoder)
+            .map(Result::unwrap)
+            .collect()
+            .await;
+        let output = String::from_utf8(output.concat()).unwrap();
+
+        let mut content = String::new();
+        let mut done_count = 0;
+        for block in output.split("\n\n") {
+            let Some(data) = block.strip_prefix("data: ") else {
+                continue;
+            };
+            if data == "[DONE]" {
+                done_count += 1;
+                continue;
+            }
+            let chunk: Value = serde_json::from_str(data).unwrap();
+            if let Some(delta) = chunk
+                .pointer("/choices/0/delta/content")
+                .and_then(Value::as_str)
+            {
+                content.push_str(delta);
+            }
+        }
+
+        assert_eq!(content, "A汉字🚀");
+        assert_eq!(done_count, 1);
+    }
+}

--- a/src/channel/bulletins/chatgpt/sse.rs
+++ b/src/channel/bulletins/chatgpt/sse.rs
@@ -104,6 +104,17 @@ impl SseDecoder {
         }
     }
 
+    /// End the byte stream, decoding and dispatching a final unterminated
+    /// line or event block when the upstream omits SSE trailing newlines.
+    pub fn finish(&mut self) {
+        self.utf8.flush(&mut self.line_buf);
+        if !self.line_buf.is_empty() {
+            let line = std::mem::take(&mut self.line_buf);
+            self.handle_line(line.trim_end_matches('\r'));
+        }
+        self.dispatch_block();
+    }
+
     fn handle_line(&mut self, line: &str) {
         if line.is_empty() {
             self.dispatch_block();
@@ -308,6 +319,21 @@ mod tests {
         } else {
             panic!();
         }
+    }
+
+    #[test]
+    fn finish_dispatches_unterminated_multibyte_event() {
+        let body = "data: {\"v\":[{\"p\":\"/x\",\"o\":\"append\",\"v\":\"汉字🚀\"}]}".as_bytes();
+        let mut d = SseDecoder::new();
+        for byte in body {
+            d.feed(std::slice::from_ref(byte));
+        }
+        d.finish();
+
+        let Event::Delta(delta) = d.next_event().unwrap() else {
+            panic!("expected delta");
+        };
+        assert_eq!(delta.patches[0].value, serde_json::json!("汉字🚀"));
     }
 
     #[test]

--- a/src/channel/bulletins/chatgpt/sse.rs
+++ b/src/channel/bulletins/chatgpt/sse.rs
@@ -334,6 +334,9 @@ mod tests {
             panic!("expected delta");
         };
         assert_eq!(delta.patches[0].value, serde_json::json!("汉字🚀"));
+
+        d.finish();
+        assert!(d.next_event().is_none());
     }
 
     #[test]

--- a/src/channel/bulletins/chatgpt/sse_to_openai.rs
+++ b/src/channel/bulletins/chatgpt/sse_to_openai.rs
@@ -414,6 +414,7 @@ pub fn collect_all(model: &str, body: &[u8]) -> Vec<OpenAiChunk> {
     let mut converter = SseToOpenAi::with_model(model);
     let mut out = Vec::new();
     decoder.feed(body);
+    decoder.finish();
     while let Some(event) = decoder.next_event() {
         if let Some(chunk) = converter.on_event(event) {
             out.push(chunk);

--- a/src/channel/bulletins/chatgpt/sse_to_openai/tests.rs
+++ b/src/channel/bulletins/chatgpt/sse_to_openai/tests.rs
@@ -122,3 +122,14 @@ data: [DONE]\n\n";
     );
     assert!(!content.contains('\u{e200}') && !content.contains('\u{e202}'));
 }
+
+#[test]
+fn preserves_unterminated_multibyte_final_event() {
+    let body = r#"event: delta
+data: {"p":"","o":"add","v":{"message":{"id":"asst","author":{"role":"assistant"},"content":{"content_type":"text","parts":[""]},"status":"in_progress","metadata":{"model_slug":"gpt-5"}},"conversation_id":"c1"},"c":0}
+
+event: delta
+data: {"v":[{"p":"/message/content/parts/0","o":"append","v":"汉字🚀"}]}"#;
+    let chunks = collect_all("gpt-5", body.as_bytes());
+    assert_eq!(joined(&chunks, "content"), "汉字🚀");
+}


### PR DESCRIPTION
## Summary

- add an EOF finalization path to the ChatGPT-specific SSE decoder
- flush pending UTF-8 bytes and dispatch a trailing line/event block when upstream omits final SSE newlines
- use finalization in live ChatGPT streaming, buffered image-pointer extraction, and the test aggregation helper
- add regressions for unterminated CJK/emoji events, production stream wiring, buffered image pointers, and repeated finalization

Fixes #128.

## Root cause

The shared SSE decoder added in v2.1.2 correctly buffers UTF-8 sequences split across network chunks and exposes `finish()`. The ChatGPT-specific SSE-v1 decoder adopted the incremental UTF-8 decoder but only exposed `feed()`. At EOF, a final line without `\n`, an event block without a trailing blank line, or pending incomplete UTF-8 bytes remained buffered and were never parsed.

## Impact

ChatGPT streaming now preserves the final event when the upstream closes with an unterminated SSE event block. This is a compatibility measure for the ChatGPT-specific stream rather than a change to the provider-neutral SSE contract. Buffered image responses use the same behavior, preventing a final asset-pointer event from being dropped.

The regression suite exercises the real `channel_decode_stream` → `ChatGptStreamDecoder::finish` path with CRLF, a UTF-8 split inside an emoji, and exactly one downstream `[DONE]`. A separate image fixture protects buffered EOF pointer extraction.

## Validation

- `cargo fmt --check`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `cargo test --workspace --all-features`
  - 625 main-library tests passed; 2 live-service tests ignored
  - 5 protocol, 4 tokenize, and 49 transform tests passed
  - 1 external-service doc test ignored
- mutation checks confirmed the production stream test fails when its `self.decoder.finish()` call is removed, and the image test fails when buffered extraction omits `decoder.finish()`
