### PR TITLE
fix(protocol): accept replayed assistant history in Responses easy-input content

### DIFF
--- a/crates/gproxy-protocol/src/protocol/openai/generate_content/response_items.rs
+++ b/crates/gproxy-protocol/src/protocol/openai/generate_content/response_items.rs
@@ -50,14 +50,27 @@ impl<'de> Deserialize<'de> for ResponseItem {
                 .map_err(de::Error::custom)?;
 
         match item_type {
+            // A *known* item type whose payload this build cannot parse — e.g. a
+            // content-part tag introduced by a newer client — must not fail the whole
+            // request. Fall back to `Unknown`, which keeps the raw JSON intact, instead
+            // of bubbling up as `did not match any variant of untagged enum ResponseInput`
+            // (a hard 422 that takes down every request in the conversation).
             ResponseItemType::Known(ResponseItemTypeKnown::Message) => {
-                serde_json::from_value(value)
-                    .map(Self::Message)
-                    .map_err(de::Error::custom)
+                match serde_json::from_value::<ResponseMessageItem>(value.clone()) {
+                    Ok(message) => Ok(Self::Message(message)),
+                    Err(_) => serde_json::from_value(value)
+                        .map(Self::Unknown)
+                        .map_err(de::Error::custom),
+                }
             }
-            ResponseItemType::Known(_) => serde_json::from_value(value)
-                .map(Self::Typed)
-                .map_err(de::Error::custom),
+            ResponseItemType::Known(_) => {
+                match serde_json::from_value::<TypedResponseItem>(value.clone()) {
+                    Ok(typed) => Ok(Self::Typed(typed)),
+                    Err(_) => serde_json::from_value(value)
+                        .map(Self::Unknown)
+                        .map_err(de::Error::custom),
+                }
+            }
             ResponseItemType::Unknown(_) => serde_json::from_value(value)
                 .map(Self::Unknown)
                 .map_err(de::Error::custom),

--- a/crates/gproxy-protocol/src/protocol/openai/generate_content/response_items/content.rs
+++ b/crates/gproxy-protocol/src/protocol/openai/generate_content/response_items/content.rs
@@ -17,12 +17,54 @@ pub enum ResponseOutput {
 pub enum ResponseEasyInputContent {
     Text(String),
     Parts(Vec<ResponseInputContentPart>),
+    // `ResponseEasyInputMessageRole` accepts `assistant`, and replayed assistant history
+    // (e.g. `codex exec resume`) carries `output_text` / `refusal` parts with no `id` or
+    // `status` — so it lands here rather than in `ResponseOutputMessageItem`. Without this
+    // variant every multi-turn Responses request fails to deserialize.
+    OutputParts(Vec<ResponseMessageOutputContentPart>),
+    // Last resort for arrays that match neither strict arm — i.e. a part tag this build
+    // does not know, possibly mixed with parts it does. Keeping the raw values lets the
+    // transform salvage the recognizable parts instead of dropping the whole message,
+    // which is what a catch-all on the part enums cannot do without breaking the
+    // untagged dispatch above.
+    Raw(Vec<serde_json::Value>),
+}
+
+impl ResponseEasyInputContent {
+    /// Best-effort text extraction from [`Self::Raw`]: pulls the text out of any part
+    /// shape this build recognizes and silently skips the rest.
+    pub fn raw_parts_text(parts: &[serde_json::Value]) -> String {
+        parts
+            .iter()
+            .filter_map(|part| {
+                let object = part.as_object()?;
+                match object.get("type").and_then(serde_json::Value::as_str)? {
+                    "input_text" | "text" | "output_text" | "summary_text"
+                    | "reasoning_text" => Some(
+                        object
+                            .get("text")
+                            .and_then(serde_json::Value::as_str)?
+                            .to_owned(),
+                    ),
+                    "refusal" => Some(format!(
+                        "[refusal: {}]",
+                        object.get("refusal").and_then(serde_json::Value::as_str)?
+                    )),
+                    "encrypted_content" => Some("[encrypted content omitted]".to_owned()),
+                    _ => None,
+                }
+            })
+            .collect::<Vec<_>>()
+            .join("")
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(tag = "type")]
 pub enum ResponseInputContentPart {
-    #[serde(rename = "input_text")]
+    // `text` is the plain variant in the Responses spec; accept it as an alias so
+    // clients that emit `{"type":"text"}` don't fail the whole request.
+    #[serde(rename = "input_text", alias = "text")]
     InputText {
         text: String,
         #[serde(skip_serializing_if = "Option::is_none")]
@@ -66,12 +108,19 @@ pub enum ResponseInputContentPart {
         #[serde(default, flatten, skip_serializing_if = "BTreeMap::is_empty")]
         extra: Extra,
     },
+    // NOTE: deliberately no `#[serde(other)]` fallback here. This enum is one of two
+    // `Vec` arms of the untagged `ResponseEasyInputContent`; a catch-all would make
+    // `Parts` match any array and swallow `output_text` into it, emptying assistant
+    // history. Unknown tags are handled by `ResponseEasyInputContent::Raw` instead.
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(tag = "type")]
 pub enum ResponseToolOutputContentPart {
-    #[serde(rename = "input_text")]
+    // Tool outputs on the wire mix codex-rs `FunctionCallOutputContentItem`
+    // (input_text | input_image | encrypted_content) with legacy output blocks,
+    // so accept `text` / `output_text` as aliases of the same text payload.
+    #[serde(rename = "input_text", alias = "text", alias = "output_text")]
     InputText {
         text: String,
         #[serde(skip_serializing_if = "Option::is_none")]
@@ -109,12 +158,31 @@ pub enum ResponseToolOutputContentPart {
         #[serde(default, flatten, skip_serializing_if = "BTreeMap::is_empty")]
         extra: Extra,
     },
+    // codex-rs `FunctionCallOutputContentItem::EncryptedContent`: an opaque
+    // round-trip payload. Accepted so the request deserializes; dropped when
+    // converting downstream since no non-OpenAI upstream can interpret it.
+    #[serde(rename = "encrypted_content")]
+    EncryptedContent {
+        encrypted_content: String,
+        #[serde(default, flatten, skip_serializing_if = "BTreeMap::is_empty")]
+        extra: Extra,
+    },
+    // Legacy output block that can appear in tool results on the wire.
+    #[serde(rename = "refusal")]
+    Refusal {
+        refusal: String,
+        #[serde(default, flatten, skip_serializing_if = "BTreeMap::is_empty")]
+        extra: Extra,
+    },
+    // See `ResponseInputContentPart::Unknown`.
+    #[serde(other)]
+    Unknown,
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(tag = "type")]
 pub enum ResponseMessageOutputContentPart {
-    #[serde(rename = "output_text")]
+    #[serde(rename = "output_text", alias = "text")]
     OutputText {
         #[serde(default, skip_serializing_if = "Vec::is_empty")]
         annotations: Vec<ResponseAnnotation>,
@@ -130,6 +198,9 @@ pub enum ResponseMessageOutputContentPart {
         #[serde(default, flatten, skip_serializing_if = "BTreeMap::is_empty")]
         extra: Extra,
     },
+    // NOTE: no `#[serde(other)]` here either — same untagged-arm hazard as
+    // `ResponseInputContentPart`, just in the opposite direction (`OutputParts`
+    // would swallow `input_text`). See `ResponseEasyInputContent::Raw`.
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]

--- a/crates/gproxy-transform/src/transform/compact/openai_to_claude/input.rs
+++ b/crates/gproxy-transform/src/transform/compact/openai_to_claude/input.rs
@@ -137,6 +137,23 @@ fn easy_input_content_to_blocks(
     match content {
         openai::ResponseEasyInputContent::Text(text) => text_block(text).into_iter().collect(),
         openai::ResponseEasyInputContent::Parts(parts) => input_parts_to_blocks(parts),
+        // Replayed assistant history (`output_text` / `refusal`) flattened to text.
+        openai::ResponseEasyInputContent::OutputParts(parts) => text_block(
+            parts
+                .into_iter()
+                .map(|part| match part {
+                    openai::ResponseMessageOutputContentPart::OutputText { text, .. } => text,
+                    openai::ResponseMessageOutputContentPart::Refusal { refusal, .. } => {
+                        format!("[refusal: {refusal}]")
+                    }
+                })
+                .collect::<Vec<_>>()
+                .join(""),
+        )
+        .into_iter()
+        .collect(),
+        // Array with an unrecognized part tag: salvage the parts we do understand.
+        openai::ResponseEasyInputContent::Raw(parts) => text_block(openai::ResponseEasyInputContent::raw_parts_text(&parts)).into_iter().collect(),
     }
 }
 

--- a/crates/gproxy-transform/src/transform/compact/openai_to_claude/tools.rs
+++ b/crates/gproxy-transform/src/transform/compact/openai_to_claude/tools.rs
@@ -235,6 +235,28 @@ fn tool_output_part_to_claude(
             }
             _ => None,
         }),
+        // Opaque codex round-trip payload; leave a marker rather than dropping it, so
+        // the tool result does not look empty to the routed model.
+        openai::ResponseToolOutputContentPart::EncryptedContent { .. } => {
+            Some(claude::ToolResultContentBlock::Text(claude::TextBlock {
+                text: "[encrypted content omitted]".to_owned(),
+                type_: claude::TextBlockType::Text,
+                cache_control: None,
+                citations: None,
+                extra: Default::default(),
+            }))
+        }
+        openai::ResponseToolOutputContentPart::Refusal { refusal, .. } => {
+            Some(claude::ToolResultContentBlock::Text(claude::TextBlock {
+                text: format!("[refusal: {refusal}]"),
+                type_: claude::TextBlockType::Text,
+                cache_control: None,
+                citations: None,
+                extra: Default::default(),
+            }))
+        }
+        // Unknown content-part tag: skip this part, keep the rest of the message.
+        openai::ResponseToolOutputContentPart::Unknown => None,
     }
 }
 

--- a/crates/gproxy-transform/src/transform/count_tokens/common/text.rs
+++ b/crates/gproxy-transform/src/transform/count_tokens/common/text.rs
@@ -39,6 +39,20 @@ fn openai_easy_content_text(content: openai::ResponseEasyInputContent) -> String
     match content {
         openai::ResponseEasyInputContent::Text(text) => text,
         openai::ResponseEasyInputContent::Parts(parts) => response_input_parts_text(parts),
+        // Replayed assistant history (`output_text` / `refusal`) counts as its text,
+        // matching the tagged form the transform actually emits.
+        openai::ResponseEasyInputContent::OutputParts(parts) => parts
+            .into_iter()
+            .map(|part| match part {
+                openai::ResponseMessageOutputContentPart::OutputText { text, .. } => text,
+                openai::ResponseMessageOutputContentPart::Refusal { refusal, .. } => {
+                    format!("[refusal: {refusal}]")
+                }
+            })
+            .collect::<Vec<_>>()
+            .join(""),
+        // Array with an unrecognized part tag: salvage the parts we do understand.
+        openai::ResponseEasyInputContent::Raw(parts) => openai::ResponseEasyInputContent::raw_parts_text(&parts),
     }
 }
 

--- a/crates/gproxy-transform/src/transform/generate_content/openai_responses_to_openai_chat/content/input.rs
+++ b/crates/gproxy-transform/src/transform/generate_content/openai_responses_to_openai_chat/content/input.rs
@@ -117,6 +117,22 @@ fn easy_message_to_chat_message(
     })
 }
 
+/// Flattens replayed assistant history (`output_text` / `refusal`) into plain text.
+/// A refusal is tagged rather than inlined bare, so the routed model can tell it
+/// apart from ordinary assistant prose.
+fn message_output_parts_text(parts: Vec<openai::ResponseMessageOutputContentPart>) -> String {
+    parts
+        .into_iter()
+        .map(|part| match part {
+            openai::ResponseMessageOutputContentPart::OutputText { text, .. } => text,
+            openai::ResponseMessageOutputContentPart::Refusal { refusal, .. } => {
+                format!("[refusal: {refusal}]")
+            }
+        })
+        .collect::<Vec<_>>()
+        .join("")
+}
+
 fn easy_input_content_to_chat_content(
     content: openai::ResponseEasyInputContent,
 ) -> openai::ChatContent {
@@ -125,6 +141,11 @@ fn easy_input_content_to_chat_content(
         openai::ResponseEasyInputContent::Parts(parts) => {
             response_input_parts_to_chat_content(parts)
         }
+        openai::ResponseEasyInputContent::OutputParts(parts) => {
+            openai::ChatContent::Text(message_output_parts_text(parts))
+        }
+        // Array with an unrecognized part tag: salvage the parts we do understand.
+        openai::ResponseEasyInputContent::Raw(parts) => openai::ChatContent::Text(openai::ResponseEasyInputContent::raw_parts_text(&parts)),
     }
 }
 
@@ -136,6 +157,11 @@ fn easy_input_content_to_chat_text_content(
         openai::ResponseEasyInputContent::Parts(parts) => {
             response_input_parts_to_chat_text_content(parts)
         }
+        openai::ResponseEasyInputContent::OutputParts(parts) => {
+            openai::ChatTextContent::Text(message_output_parts_text(parts))
+        }
+        // Array with an unrecognized part tag: salvage the parts we do understand.
+        openai::ResponseEasyInputContent::Raw(parts) => openai::ChatTextContent::Text(openai::ResponseEasyInputContent::raw_parts_text(&parts)),
     }
 }
 
@@ -144,6 +170,9 @@ fn easy_input_content_to_chat_assistant_content(
 ) -> openai::ChatAssistantContent {
     match content {
         openai::ResponseEasyInputContent::Text(text) => openai::ChatAssistantContent::Text(text),
+        openai::ResponseEasyInputContent::OutputParts(parts) => {
+            openai::ChatAssistantContent::Text(message_output_parts_text(parts))
+        }
         openai::ResponseEasyInputContent::Parts(parts) => openai::ChatAssistantContent::Parts(
             parts
                 .into_iter()
@@ -164,6 +193,8 @@ fn easy_input_content_to_chat_assistant_content(
                 })
                 .collect(),
         ),
+        // Array with an unrecognized part tag: salvage the parts we do understand.
+        openai::ResponseEasyInputContent::Raw(parts) => openai::ChatAssistantContent::Text(openai::ResponseEasyInputContent::raw_parts_text(&parts)),
     }
 }
 

--- a/crates/gproxy-transform/src/transform/generate_content/openai_responses_to_openai_chat/content/util.rs
+++ b/crates/gproxy-transform/src/transform/generate_content/openai_responses_to_openai_chat/content/util.rs
@@ -38,6 +38,25 @@ pub(super) fn response_output_to_chat_content(
                         );
                         None
                     }
+                    // Opaque codex round-trip payload. No routed model can read it, but
+                    // dropping it silently makes the tool look like it returned nothing,
+                    // which invites the model to re-run the call — leave a marker.
+                    openai::ResponseToolOutputContentPart::EncryptedContent { .. } => {
+                        Some(openai::ChatTextContentPart::Text {
+                            text: "[encrypted content omitted]".to_owned(),
+                            prompt_cache_breakpoint: None,
+                            extra: Default::default(),
+                        })
+                    }
+                    openai::ResponseToolOutputContentPart::Refusal { refusal, .. } => {
+                        Some(openai::ChatTextContentPart::Text {
+                            text: format!("[refusal: {refusal}]"),
+                            prompt_cache_breakpoint: None,
+                            extra: Default::default(),
+                        })
+                    }
+                    // Unknown content-part tag: skip this part, keep the rest of the message.
+                    openai::ResponseToolOutputContentPart::Unknown => None,
                 })
                 .collect(),
         ),


### PR DESCRIPTION
Fixes #146.

Multi-turn Codex requests against `claudecode/*` died at decode time with `did not match any variant of untagged enum ResponseInput` (422), because `codex exec resume` replays assistant turns with **neither `id` nor `status`**, which routes them to `ResponseMessageItem::EasyInput`, whose content only permitted `input_*` parts.

## What changed

**`crates/gproxy-protocol/.../response_items/content.rs`**

| change | why |
|---|---|
| `ResponseEasyInputContent::OutputParts(Vec<ResponseMessageOutputContentPart>)` | the actual fix — lets an easy-input message carry `output_text` / `refusal` |
| `ResponseEasyInputContent::Raw(Vec<Value>)` + `raw_parts_text()` | last-resort arm for arrays holding an unrecognized tag; salvages the parts that *are* understood instead of losing the message |
| `ResponseInputContentPart::InputText`: `alias = "text"` | plain `text` is a valid Responses part type |
| `ResponseToolOutputContentPart::InputText`: `alias = "text"`, `alias = "output_text"` | tool results mix input/output text shapes on the wire |
| `ResponseToolOutputContentPart::EncryptedContent` | codex-rs `FunctionCallOutputContentItem::EncryptedContent` |
| `ResponseToolOutputContentPart::Refusal` | legacy output block that can appear in tool results |
| `ResponseToolOutputContentPart`: `#[serde(other)] Unknown` | per-part skip for unknown tool-output tags |
| `ResponseMessageOutputContentPart::OutputText`: `alias = "text"` | same as above, assistant direction |

**`crates/gproxy-protocol/.../response_items.rs`** — `ResponseItem::deserialize` now falls back to `Unknown` when a *known* item type fails to parse, instead of bubbling up and failing the whole request. Previously only an unknown *item type* was tolerated, so any future content-part addition would be a hard 422 again.

**Transform (5 files)** — new match arms, plus two rendering choices:

- refusals render as `[refusal: ...]` rather than inlined bare, so a routed model can distinguish them from ordinary assistant prose
- `encrypted_content` renders as `[encrypted content omitted]` rather than being dropped silently — a silently empty tool result invites the model to re-run the call

## One trap worth flagging

`#[serde(other)]` **cannot** be added to `ResponseInputContentPart` or `ResponseMessageOutputContentPart`. Both are `Vec` arms of the same untagged `ResponseEasyInputContent`; a catch-all on either makes its arm match *any* array and swallow the other arm's content into `Unknown`, emptying it. I tried exactly that first and it produced 400s on `assistant` + `input_text` (content became empty upstream). That is why the fallback lives in `Raw` instead, and why `ResponseToolOutputContentPart` *can* have the catch-all — its `ResponseOutput` has only one `Vec` arm, so there is no competing arm to starve.

`OutputParts` is also declared **after** `Parts` on purpose: both are strict, and `input_*` tags do not exist in the output enum, so ordinary input bodies keep matching `Parts` byte-for-byte as before.

## Blast radius

- **Additive only**: no existing variant, field or arm was removed or retyped; `+196 −9`.
- Bodies that already worked take the same path they did before — `input_text` still matches `Parts`, verified as a regression case.
- `Raw` and the `ResponseItem::Unknown` fallback only engage on input that previously produced a hard 422, so they cannot change the behaviour of currently-working requests.
- Serialization is unaffected: the new arms are only produced by inbound decoding, and the transform consumes them into Anthropic/Chat shapes.
- Touches the `openai_responses_to_openai_chat`, `compact/openai_to_claude` and `count_tokens` paths. `count_tokens` was updated to the same tagged rendering so counts match what is actually sent.

## Testing

Built from `81043a4b` (matching the released binary, `gproxy --version` → 2.1.5) and run as the live gateway.

**Status codes — 13/13 (was 8 failing)**

| case | before | after |
|---|---|---|
| assistant `output_text` / `refusal` / `text` | 422 | **200** |
| assistant `input_text` (regression guard) | 200 | **200** |
| tool output `input_text` | 200 | **200** |
| tool output `encrypted_content` / `output_text` / `refusal` | 422 | **200** |
| user plain `text` | 422 | **200** |
| unknown *item* type | 200 | **200** |
| unknown tool-output part (mixed with a valid one) | 422 | **200** |
| unknown message part (mixed with a valid one) | 422 | **200** |
| `/console` | 200 | **200** |

**Upstream body assertions** — grepped `upstream_requests` to confirm the transform output, not just the status code:

| expected in the Anthropic request | found |
|---|---|
| the `input_text` sitting *next to* an unknown message part | ✅ (message is `user/text: PARTKEEP-9931`, unknown part skipped) |
| the `input_text` next to an unknown tool-output part | ✅ |
| `[refusal: nope]` | ✅ |
| `[encrypted content omitted]` | ✅ |

**End-to-end, real client** — `codex exec` + `codex exec resume` on `claudecode/claude-opus-4-8`, three separate runs (direct, through a tunnel, and through a Feishu bot). Memory probes confirm history is not merely accepted but correctly translated:

```
turn 1  "remember this number: 4271"     → OK          (input 19,741 tok)
turn 2  "what number did I ask you to remember?" → 4271   (input 39,507 tok)
```

The same thread that previously exhausted all 5 retries with 422 now completes in ~7s, and `upstream_requests` shows `message.model = "claude-opus-4-8"` with `assistant/output_text` present in the request.

`cargo check --workspace` and `cargo build --release` both clean (0 errors). The console assets are unaffected (`pnpm build` → `sync-to-embed` unchanged; binary stays 31M with the embedded SPA intact).
