### PR TITLE
[codex] support OpenAI ultrafast service tier

### DIFF
--- a/crates/gproxy-protocol/src/protocol/openai/common/enums/content.rs
+++ b/crates/gproxy-protocol/src/protocol/openai/common/enums/content.rs
@@ -33,6 +33,7 @@ strict_string_enum!(ServiceTier {
     Flex => "flex",
     Scale => "scale",
     Priority => "priority",
+    Ultrafast => "ultrafast",
     OnDemand => "on_demand",
 });
 
@@ -105,6 +106,23 @@ strict_string_enum!(AudioResponseFormat {
     Opus => "opus",
     Pcm16 => "pcm16",
 });
+
+#[cfg(test)]
+mod tests {
+    use super::ServiceTier;
+
+    #[test]
+    fn ultrafast_service_tier_uses_openai_wire_value() {
+        assert_eq!(
+            serde_json::to_value(ServiceTier::Ultrafast).unwrap(),
+            serde_json::json!("ultrafast")
+        );
+        assert_eq!(
+            serde_json::from_value::<ServiceTier>(serde_json::json!("ultrafast")).unwrap(),
+            ServiceTier::Ultrafast
+        );
+    }
+}
 
 extensible_string_enum!(VoiceName, VoiceNameKnown {
     Alloy => "alloy",

--- a/crates/gproxy-transform/src/transform/compact/openai_responses_to_openai_compact/request.rs
+++ b/crates/gproxy-transform/src/transform/compact/openai_responses_to_openai_compact/request.rs
@@ -29,10 +29,25 @@ fn service_tier_to_compact(service_tier: openai::ServiceTier) -> openai::Compact
         openai::ServiceTier::Fast => openai::CompactServiceTier::Fast,
         openai::ServiceTier::Flex => openai::CompactServiceTier::Flex,
         openai::ServiceTier::Priority => openai::CompactServiceTier::Priority,
+        // Compact does not expose `ultrafast`; preserve the closest supported speed tier.
+        openai::ServiceTier::Ultrafast => openai::CompactServiceTier::Fast,
         // `scale` has no compact equivalent; fall back to auto.
         openai::ServiceTier::Scale => openai::CompactServiceTier::Auto,
         _ => {
             unreachable!("new non-exhaustive protocol variant requires a lockstep transform update")
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn ultrafast_falls_back_to_fast_for_compact() {
+        assert_eq!(
+            service_tier_to_compact(openai::ServiceTier::Ultrafast),
+            openai::CompactServiceTier::Fast
+        );
     }
 }

--- a/crates/gproxy-transform/src/transform/count_tokens/common/generation/service_tier.rs
+++ b/crates/gproxy-transform/src/transform/count_tokens/common/generation/service_tier.rs
@@ -27,9 +27,9 @@ pub(in crate::transform::count_tokens) fn openai_service_tier_to_gemini(
             gemini::ServiceTierKnown::Standard
         }
         openai::ServiceTier::Flex => gemini::ServiceTierKnown::Flex,
-        openai::ServiceTier::Fast | openai::ServiceTier::Priority => {
-            gemini::ServiceTierKnown::Priority
-        }
+        openai::ServiceTier::Fast
+        | openai::ServiceTier::Priority
+        | openai::ServiceTier::Ultrafast => gemini::ServiceTierKnown::Priority,
         openai::ServiceTier::Scale => gemini::ServiceTierKnown::Standard,
         _ => {
             unreachable!("new non-exhaustive protocol variant requires a lockstep transform update")
@@ -69,7 +69,8 @@ pub(in crate::transform::count_tokens) fn openai_service_tier_to_claude(
         openai::ServiceTier::Fast
         | openai::ServiceTier::Flex
         | openai::ServiceTier::Scale
-        | openai::ServiceTier::Priority => claude::RequestServiceTierKnown::Auto,
+        | openai::ServiceTier::Priority
+        | openai::ServiceTier::Ultrafast => claude::RequestServiceTierKnown::Auto,
         _ => {
             unreachable!("new non-exhaustive protocol variant requires a lockstep transform update")
         }
@@ -115,9 +116,11 @@ pub(in crate::transform::count_tokens) fn openai_service_tier_to_claude_speed(
     service_tier: Option<openai::ServiceTier>,
 ) -> Option<claude::Speed> {
     match service_tier {
-        Some(openai::ServiceTier::Fast | openai::ServiceTier::Priority) => {
-            Some(claude::Speed::Known(claude::SpeedKnown::Fast))
-        }
+        Some(
+            openai::ServiceTier::Fast
+            | openai::ServiceTier::Priority
+            | openai::ServiceTier::Ultrafast,
+        ) => Some(claude::Speed::Known(claude::SpeedKnown::Fast)),
         _ => None,
     }
 }
@@ -159,10 +162,16 @@ mod tests {
 
     #[test]
     fn preserves_fast_semantics_for_count_tokens() {
-        assert_eq!(
-            openai_service_tier_to_claude_speed(Some(openai::ServiceTier::Fast)),
-            Some(claude::Speed::Known(claude::SpeedKnown::Fast))
-        );
+        for tier in [
+            openai::ServiceTier::Fast,
+            openai::ServiceTier::Priority,
+            openai::ServiceTier::Ultrafast,
+        ] {
+            assert_eq!(
+                openai_service_tier_to_claude_speed(Some(tier)),
+                Some(claude::Speed::Known(claude::SpeedKnown::Fast))
+            );
+        }
         assert_eq!(
             claude_speed_to_openai(Some(claude::Speed::Known(claude::SpeedKnown::Fast))),
             Some(openai::ServiceTier::Priority)

--- a/crates/gproxy-transform/src/transform/generate_content/common/config/service_tier.rs
+++ b/crates/gproxy-transform/src/transform/generate_content/common/config/service_tier.rs
@@ -11,7 +11,8 @@ pub(in crate::transform::generate_content) fn openai_service_tier_to_claude(
         openai::ServiceTier::Fast
         | openai::ServiceTier::Flex
         | openai::ServiceTier::Scale
-        | openai::ServiceTier::Priority => claude::RequestServiceTierKnown::Auto,
+        | openai::ServiceTier::Priority
+        | openai::ServiceTier::Ultrafast => claude::RequestServiceTierKnown::Auto,
         _ => {
             unreachable!("new non-exhaustive protocol variant requires a lockstep transform update")
         }
@@ -61,9 +62,9 @@ pub(in crate::transform::generate_content) fn openai_service_tier_to_gemini(
             gemini::ServiceTierKnown::Standard
         }
         openai::ServiceTier::Flex => gemini::ServiceTierKnown::Flex,
-        openai::ServiceTier::Fast | openai::ServiceTier::Priority => {
-            gemini::ServiceTierKnown::Priority
-        }
+        openai::ServiceTier::Fast
+        | openai::ServiceTier::Priority
+        | openai::ServiceTier::Ultrafast => gemini::ServiceTierKnown::Priority,
         openai::ServiceTier::Scale => gemini::ServiceTierKnown::Standard,
         _ => {
             unreachable!("new non-exhaustive protocol variant requires a lockstep transform update")

--- a/crates/gproxy-transform/src/transform/generate_content/common/config/speed.rs
+++ b/crates/gproxy-transform/src/transform/generate_content/common/config/speed.rs
@@ -4,9 +4,11 @@ pub(in crate::transform::generate_content) fn openai_service_tier_to_claude_spee
     service_tier: Option<openai::ServiceTier>,
 ) -> Option<claude::Speed> {
     match service_tier {
-        Some(openai::ServiceTier::Fast | openai::ServiceTier::Priority) => {
-            Some(claude::Speed::Known(claude::SpeedKnown::Fast))
-        }
+        Some(
+            openai::ServiceTier::Fast
+            | openai::ServiceTier::Priority
+            | openai::ServiceTier::Ultrafast,
+        ) => Some(claude::Speed::Known(claude::SpeedKnown::Fast)),
         _ => None,
     }
 }
@@ -55,7 +57,11 @@ mod tests {
 
     #[test]
     fn maps_fast_semantics_across_protocols() {
-        for tier in [openai::ServiceTier::Fast, openai::ServiceTier::Priority] {
+        for tier in [
+            openai::ServiceTier::Fast,
+            openai::ServiceTier::Priority,
+            openai::ServiceTier::Ultrafast,
+        ] {
             assert_eq!(
                 openai_service_tier_to_claude_speed(Some(tier)),
                 Some(claude::Speed::Known(claude::SpeedKnown::Fast))

--- a/crates/gproxy-transform/src/transform/generate_content/openai_chat_to_claude_messages/request.rs
+++ b/crates/gproxy-transform/src/transform/generate_content/openai_chat_to_claude_messages/request.rs
@@ -266,8 +266,12 @@ mod tests {
     }
 
     #[test]
-    fn maps_openai_fast_and_priority_service_tiers_to_claude_speed() {
-        for tier in [openai::ServiceTier::Fast, openai::ServiceTier::Priority] {
+    fn maps_openai_fast_service_tiers_to_claude_speed() {
+        for tier in [
+            openai::ServiceTier::Fast,
+            openai::ServiceTier::Priority,
+            openai::ServiceTier::Ultrafast,
+        ] {
             assert_eq!(
                 common::openai_service_tier_to_claude_speed(Some(tier)),
                 Some(claude::Speed::Known(claude::SpeedKnown::Fast))


### PR DESCRIPTION
## Summary

- add the OpenAI `ultrafast` service tier to the shared protocol enum
- preserve Ultrafast across native OpenAI Chat, Responses, and WebSocket paths
- map Ultrafast to the closest supported fast tier for Claude, Gemini, count-token, and Compact transforms
- add serialization and transform regression coverage

## Why

OpenAI introduced an access-controlled Ultrafast processing tier for `gpt-5.6-sol`. Without the new enum variant, protocol decoding rejects `service_tier: "ultrafast"`, and exhaustive transform mappings cannot handle requests or responses using the tier.

Compact does not currently expose an `ultrafast` value, so Responses-to-Compact conversion intentionally falls back to `fast`. Claude uses `speed: "fast"`, and Gemini uses its priority tier.

## Impact

Clients can send and receive OpenAI Ultrafast requests through GPROXY. Cross-provider conversions retain the closest available low-latency semantics instead of failing.

## Validation

- `cargo test -p gproxy-protocol -p gproxy-transform`
- `cargo check --workspace --all-targets`
- `git diff --check`
