### PR TITLE
[codex] fix Cline auth and Claude stream blocks

### DIFF
--- a/console/src/lib/channel-meta.test.ts
+++ b/console/src/lib/channel-meta.test.ts
@@ -125,6 +125,16 @@ describe("Kimi API fallback metadata", () => {
   });
 });
 
+describe("Cline fallback metadata", () => {
+  it("treats pasted credentials as API keys while retaining device login", () => {
+    expect(channelMeta("cline")).toMatchObject({
+      family: "api_key",
+      loginModes: ["device"],
+      secretTemplate: { api_key: "" },
+    });
+  });
+});
+
 describe("Kimi Code fallback metadata", () => {
   it("uses the managed coding endpoint and device OAuth", () => {
     expect(DEFAULT_BASE_URL.kimicode).toBe("https://api.kimi.com/coding/v1");

--- a/console/src/lib/channel-meta.ts
+++ b/console/src/lib/channel-meta.ts
@@ -220,8 +220,9 @@ export const CHANNELS: ChannelMeta[] = [
       domain: "",
     },
   }),
-  oauthMeta("cline", ["device"], {
-    secretTemplate: { ...OAUTH_TOKENS, api_key: "" },
+  builtinMeta("cline", "api_key", {
+    loginModes: ["device"],
+    usage: true,
   }),
   oauthMeta("kiro", ["authcode", "device"]),
   builtinMeta("copilotcli", "github_token", {

--- a/crates/gproxy-transform/src/transform/generate_content/common/stream.rs
+++ b/crates/gproxy-transform/src/transform/generate_content/common/stream.rs
@@ -41,7 +41,8 @@ enum ClaudeBlockKind {
 #[derive(Default)]
 pub(in crate::transform::generate_content) struct ClaudeStreamLifecycle {
     message_started: bool,
-    open_blocks: BTreeMap<u64, ClaudeBlockKind>,
+    open_blocks: BTreeMap<u64, (ClaudeBlockKind, u64)>,
+    next_block_index: u64,
     terminated: bool,
 }
 
@@ -58,12 +59,12 @@ impl ClaudeStreamLifecycle {
             if self.terminated {
                 break;
             }
-            match &event {
-                claude::StreamEvent::Known(known) => match known.as_ref() {
+            match event {
+                claude::StreamEvent::Known(mut known) => match known.as_mut() {
                     claude::KnownStreamEvent::MessageStart { .. } => {
                         if !self.message_started {
                             self.message_started = true;
-                            out.push(event);
+                            out.push(claude::StreamEvent::Known(known));
                         }
                     }
                     claude::KnownStreamEvent::ContentBlockStart {
@@ -74,30 +75,45 @@ impl ClaudeStreamLifecycle {
                         self.ensure_message_start(&mut out, &mut fallback_start);
                         self.close_blocks(&mut out);
                         if let Some(kind) = claude_block_kind(content_block) {
-                            self.open_blocks.insert(*index, kind);
+                            let source_index = *index;
+                            let output_index = self.allocate_block_index();
+                            self.open_blocks.insert(source_index, (kind, output_index));
+                            *index = output_index;
                         }
-                        out.push(event);
+                        out.push(claude::StreamEvent::Known(known));
                     }
                     claude::KnownStreamEvent::ContentBlockDelta { index, delta, .. } => {
                         self.ensure_message_start(&mut out, &mut fallback_start);
+                        let source_index = *index;
                         let kind = claude_delta_kind(delta).unwrap_or(ClaudeBlockKind::Text);
-                        if self.open_blocks.get(index) != Some(&kind) {
+                        let output_index = if let Some((_, output_index)) = self
+                            .open_blocks
+                            .get(&source_index)
+                            .filter(|(open_kind, _)| *open_kind == kind)
+                        {
+                            *output_index
+                        } else {
                             self.close_blocks(&mut out);
-                            out.push(claude_block_start(*index, kind));
-                            self.open_blocks.insert(*index, kind);
-                        }
-                        out.push(event);
+                            let output_index = self.allocate_block_index();
+                            out.push(claude_block_start(output_index, kind));
+                            self.open_blocks.insert(source_index, (kind, output_index));
+                            output_index
+                        };
+                        *index = output_index;
+                        out.push(claude::StreamEvent::Known(known));
                     }
                     claude::KnownStreamEvent::ContentBlockStop { index, .. } => {
-                        if self.open_blocks.remove(index).is_some() {
-                            out.push(event);
+                        let source_index = *index;
+                        if let Some((_, output_index)) = self.open_blocks.remove(&source_index) {
+                            *index = output_index;
+                            out.push(claude::StreamEvent::Known(known));
                         }
                     }
                     claude::KnownStreamEvent::MessageDelta { delta, .. } => {
                         self.ensure_message_start(&mut out, &mut fallback_start);
                         self.close_blocks(&mut out);
                         let terminal = delta.stop_reason.is_some();
-                        out.push(event);
+                        out.push(claude::StreamEvent::Known(known));
                         if terminal {
                             out.push(claude_message_stop());
                             self.terminated = true;
@@ -106,20 +122,24 @@ impl ClaudeStreamLifecycle {
                     claude::KnownStreamEvent::MessageStop { .. } => {
                         self.ensure_message_start(&mut out, &mut fallback_start);
                         self.close_blocks(&mut out);
-                        out.push(event);
+                        out.push(claude::StreamEvent::Known(known));
                         self.terminated = true;
                     }
                     claude::KnownStreamEvent::Error { .. } => {
                         self.close_blocks(&mut out);
-                        out.push(event);
+                        out.push(claude::StreamEvent::Known(known));
                         self.terminated = true;
                     }
-                    claude::KnownStreamEvent::Ping { .. } => out.push(event),
+                    claude::KnownStreamEvent::Ping { .. } => {
+                        out.push(claude::StreamEvent::Known(known));
+                    }
                     _ => unreachable!(
                         "new non-exhaustive protocol variant requires a lockstep transform update"
                     ),
                 },
-                claude::StreamEvent::Unknown(_) => out.push(event),
+                claude::StreamEvent::Unknown(event) => {
+                    out.push(claude::StreamEvent::Unknown(event));
+                }
                 _ => unreachable!(
                     "new non-exhaustive protocol variant requires a lockstep transform update"
                 ),
@@ -157,9 +177,15 @@ impl ClaudeStreamLifecycle {
     }
 
     fn close_blocks(&mut self, out: &mut Vec<claude::StreamEvent>) {
-        for index in std::mem::take(&mut self.open_blocks).into_keys() {
-            out.push(claude_content_block_stop(index));
+        for (_, (_, output_index)) in std::mem::take(&mut self.open_blocks) {
+            out.push(claude_content_block_stop(output_index));
         }
+    }
+
+    fn allocate_block_index(&mut self) -> u64 {
+        let index = self.next_block_index;
+        self.next_block_index = self.next_block_index.saturating_add(1);
+        index
     }
 }
 

--- a/crates/gproxy-transform/src/transform/stream_adapter/tests.rs
+++ b/crates/gproxy-transform/src/transform/stream_adapter/tests.rs
@@ -31,6 +31,7 @@ fn assert_claude_lifecycle(text: &str) {
     let events = sse_values(text);
     let mut started = false;
     let mut open_block = None;
+    let mut seen_blocks = std::collections::HashSet::new();
     let mut stopped = false;
     for event in &events {
         match event["type"].as_str().unwrap() {
@@ -40,7 +41,12 @@ fn assert_claude_lifecycle(text: &str) {
             }
             "content_block_start" => {
                 assert!(started && open_block.is_none());
-                open_block = event["index"].as_u64();
+                let index = event["index"].as_u64().unwrap();
+                assert!(
+                    seen_blocks.insert(index),
+                    "reused Claude block index {index}"
+                );
+                open_block = Some(index);
             }
             "content_block_delta" => {
                 assert_eq!(open_block, event["index"].as_u64());
@@ -61,6 +67,34 @@ fn assert_claude_lifecycle(text: &str) {
         events.last().and_then(|event| event["type"].as_str()),
         Some("message_stop")
     );
+}
+
+#[test]
+fn thinking_to_text_allocates_distinct_claude_block_indices() {
+    let input = concat!(
+        "data: {\"id\":\"c1\",\"object\":\"chat.completion.chunk\",\"created\":1,\"model\":\"deepseek/deepseek-v4-flash\",\"choices\":[{\"index\":0,\"delta\":{\"role\":\"assistant\",\"reasoning_content\":\"思考\"},\"finish_reason\":null}]}\n\n",
+        "data: {\"id\":\"c1\",\"object\":\"chat.completion.chunk\",\"created\":1,\"model\":\"deepseek/deepseek-v4-flash\",\"choices\":[{\"index\":0,\"delta\":{\"content\":\"OK\"},\"finish_reason\":null}]}\n\n",
+        "data: {\"id\":\"c1\",\"object\":\"chat.completion.chunk\",\"created\":1,\"model\":\"deepseek/deepseek-v4-flash\",\"choices\":[{\"index\":0,\"delta\":{},\"finish_reason\":\"stop\"}]}\n\n",
+        "data: [DONE]\n\n",
+    );
+    let text = transform_sse(
+        ContentGenerationKind::OpenAiChatCompletions,
+        ContentGenerationKind::ClaudeMessages,
+        input,
+    );
+    assert_claude_lifecycle(&text);
+    let values = sse_values(&text);
+    let starts: Vec<(u64, &str)> = values
+        .iter()
+        .filter(|event| event["type"] == "content_block_start")
+        .map(|event| {
+            (
+                event["index"].as_u64().unwrap(),
+                event["content_block"]["type"].as_str().unwrap(),
+            )
+        })
+        .collect();
+    assert_eq!(starts, vec![(0, "thinking"), (1, "text")]);
 }
 
 #[test]

--- a/src/channel/bulletins/cline/login.rs
+++ b/src/channel/bulletins/cline/login.rs
@@ -177,6 +177,7 @@ fn secret_from(tokens: ClineTokens, previous: &Value) -> Value {
         out = json!({});
     }
     let obj = out.as_object_mut().expect("object");
+    obj.insert("api_key".into(), Value::String(tokens.access_token.clone()));
     obj.insert("access_token".into(), Value::String(tokens.access_token));
     if let Some(token) = tokens.refresh_token.filter(|t| !t.is_empty()) {
         obj.insert("refresh_token".into(), Value::String(token));

--- a/src/channel/bulletins/cline/tests.rs
+++ b/src/channel/bulletins/cline/tests.rs
@@ -42,6 +42,20 @@ fn chat_op() -> OperationKey {
 }
 
 #[test]
+fn credentials_use_api_key_family_even_with_device_login() {
+    let metadata = crate::channel::metadata::builtin(&ClineChannel);
+    assert_eq!(
+        metadata.credential_family,
+        crate::channel::CredentialFamily::ApiKey
+    );
+    assert_eq!(
+        metadata.login_modes,
+        vec![crate::channel::LoginMode::Device]
+    );
+    assert_eq!(metadata.secret_template, json!({ "api_key": "" }));
+}
+
+#[test]
 fn account_tokens_are_prefixed_and_api_keys_are_not() {
     let token = prepared(
         &json!({ "access_token": "jwt-abc", "refresh_token": "rt" }),

--- a/src/channel/metadata.rs
+++ b/src/channel/metadata.rs
@@ -100,13 +100,11 @@ pub fn builtin(channel: &dyn Channel) -> ChannelMetadata {
                 "domain": ""
             });
         }
-        // Account tokens from the device login, or a pasted workspace API key —
-        // `prepare` accepts either, so the template offers both.
+        // The request credential is an API key. Device login is an additional
+        // way to obtain one and may retain refresh fields alongside it, just as
+        // OpenCode Zen/Go do.
         "cline" => {
-            metadata.credential_family = CredentialFamily::OauthTokens;
             metadata.login_modes = vec![LoginMode::Device];
-            metadata.secret_template =
-                json!({ "access_token": "", "refresh_token": "", "api_key": "" });
             metadata.usage = true;
         }
         "kiro" => oauth(

--- a/src/store/persistence/migrations.rs
+++ b/src/store/persistence/migrations.rs
@@ -525,6 +525,14 @@ pub const MIGRATIONS: &[Migration] = &[
             ],
         },
     },
+    Migration {
+        version: 26,
+        description: "classify Cline credentials as API keys",
+        sql: MigrationSql::Shared(&["UPDATE credentials SET kind = 'api_key' \
+             WHERE kind = 'oauth_tokens' AND provider_id IN (\
+                 SELECT id FROM providers WHERE channel = 'cline'\
+             )"]),
+    },
 ];
 
 /// Migrations with `version > current`, in ascending order — the work a runner

--- a/src/store/persistence/migrations/tests.rs
+++ b/src/store/persistence/migrations/tests.rs
@@ -38,3 +38,21 @@ fn postgres_max_version_query_widens_legacy_integer_tables() {
         SELECT_MAX_VERSION
     );
 }
+
+#[test]
+fn cline_credentials_migrate_to_api_key_kind_on_every_dialect() {
+    let migration = MIGRATIONS
+        .iter()
+        .find(|migration| migration.version == 26)
+        .expect("Cline credential migration");
+    for dialect in [
+        MigrationDialect::Sqlite,
+        MigrationDialect::Postgres,
+        MigrationDialect::MySql,
+    ] {
+        let sql = migration.sql_for(dialect);
+        assert_eq!(sql.len(), 1);
+        assert!(sql[0].contains("SET kind = 'api_key'"));
+        assert!(sql[0].contains("channel = 'cline'"));
+    }
+}


### PR DESCRIPTION
## What changed

- Classify Cline credentials as API keys instead of OAuth tokens, matching OpenCode Go/Zen behavior.
- Mirror the Cline device token into `api_key` and migrate existing Cline `oauth_tokens` credentials.
- Give Claude-compatible thinking and text blocks distinct sequential indexes and emit matched block-stop events.
- Add Rust and Console regression coverage.

## Why

Cline API keys were incorrectly routed through the OAuth refresh path, even though they do not require a refresh token. Separately, Claude-compatible streams reused content block index `0` when transitioning from thinking to text, which could make the VS Code Claude plugin report `content_block_delta mismatched` and stop after the thinking block.

## Impact

Existing Cline credentials are migrated automatically. Claude-compatible streaming clients now receive a valid content-block lifecycle across thinking and text output.

## Validation

- gproxy: 798 tests passed
- gproxy-transform: 101 tests passed
- Console `channel-meta.test.ts`: 9 tests passed
- Streaming probe verified thinking index `0`, text index `1`, paired stops, and `message_stop`
