### PR TITLE
[codex] fix compatible model catalog ids

### DIFF
--- a/crates/gproxy-protocol/src/protocol/openai/generate_content/response_items/typed.rs
+++ b/crates/gproxy-protocol/src/protocol/openai/generate_content/response_items/typed.rs
@@ -3,7 +3,6 @@ use std::collections::BTreeMap;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 
-use super::super::super::common::*;
 use super::super::response_tools::ResponseTool;
 use super::*;
 

--- a/src/credentials/upstream_models/parse.rs
+++ b/src/credentials/upstream_models/parse.rs
@@ -16,7 +16,8 @@ pub struct UpstreamModel {
 }
 
 /// Parse an upstream native model-list response into model metadata rows.
-/// openai/claude → `data[]` (`id`); gemini → `models[]` (`name`, `models/` stripped).
+/// openai/claude → `data[]` (`id`; OpenAI also accepts `model`);
+/// gemini → `models[]` (`name`, `models/` stripped).
 pub(super) fn parse_models(family: Provider, body: &[u8]) -> Vec<UpstreamModel> {
     let Ok(v) = serde_json::from_slice::<Value>(body) else {
         return Vec::new();
@@ -35,6 +36,11 @@ pub(super) fn parse_models(family: Provider, body: &[u8]) -> Vec<UpstreamModel> 
                     .get("name")
                     .and_then(Value::as_str)
                     .map(|s| s.strip_prefix("models/").unwrap_or(s).to_owned()),
+                Provider::OpenAi => m
+                    .get("id")
+                    .and_then(Value::as_str)
+                    .or_else(|| m.get("model").and_then(Value::as_str))
+                    .map(str::to_owned),
                 _ => m.get("id").and_then(Value::as_str).map(str::to_owned),
             }?;
             let display_name = match family {

--- a/src/credentials/upstream_models/tests.rs
+++ b/src/credentials/upstream_models/tests.rs
@@ -36,6 +36,18 @@ fn parse_openai_and_gemini() {
 }
 
 #[test]
+fn parse_openai_model_field_fallback() {
+    let models = parse_models(
+        Provider::OpenAi,
+        br#"{"data":[{"model":"anthropic/claude-opus-4-6","display_name":"Claude Opus 4.6"},{"id":"canonical-id","model":"fallback-id"}]}"#,
+    );
+
+    assert_eq!(models[0].id, "anthropic/claude-opus-4-6");
+    assert_eq!(models[0].display_name.as_deref(), Some("Claude Opus 4.6"));
+    assert_eq!(models[1].id, "canonical-id");
+}
+
+#[test]
 fn parse_openai_provider_enrichment_fields() {
     let models = parse_models(
         Provider::OpenAi,


### PR DESCRIPTION
## What changed

- accept `model` as a fallback identifier for OpenAI-compatible model catalog entries
- preserve standard `id` precedence when both fields are present
- add a regression test using the merge.dev response shape

## Root cause

The OpenAI-family parser read only `data[].id`. Compatible gateways such as merge.dev return the model identifier in `data[].model`, so every entry was filtered out and the admin model pull returned an empty list.

## Validation

- `cargo fmt --all --check`
- `cargo clippy --features full --all-targets -- -D warnings`
- `cargo test --features full` (810 passed, 1 ignored)

Fixes #190