### PR TITLE
channel(custom): forward inbound user-agent upstream

### DIFF
--- a/src/channel/bulletins/custom/mod.rs
+++ b/src/channel/bulletins/custom/mod.rs
@@ -16,8 +16,6 @@ use crate::protocol::{ContentGenerationKind, OperationKind};
 
 const DEFAULTS: ApiKeyDefaults = ApiKeyDefaults {
     default_base_url: None,
-    // Custom passthrough endpoints are often client-gated upstream (user-agent
-    // allow-lists), so forward the inbound UA to stay transparent.
     forward_headers: &["user-agent"],
     forward_query: &["after", "limit", "order", "variant"],
 };

--- a/src/channel/bulletins/custom/mod.rs
+++ b/src/channel/bulletins/custom/mod.rs
@@ -16,7 +16,9 @@ use crate::protocol::{ContentGenerationKind, OperationKind};
 
 const DEFAULTS: ApiKeyDefaults = ApiKeyDefaults {
     default_base_url: None,
-    forward_headers: &[],
+    // Custom passthrough endpoints are often client-gated upstream (user-agent
+    // allow-lists), so forward the inbound UA to stay transparent.
+    forward_headers: &["user-agent"],
     forward_query: &["after", "limit", "order", "variant"],
 };
 


### PR DESCRIPTION
部分上游供应商按 user-agent 做访问控制。但 custom 通道转发时会丢掉客户端 UA（头白名单只放行 `content-type` / `accept`），导致这类供应商对所有经网关的请求都返回 401。

现有的 header 规则集注入的 UA 也会被同一个白名单过滤掉，同样到不了上游，配置解决不了这个问题。

本 PR 在 custom 通道的透传白名单里加上 UA：

```rust
forward_headers: &["user-agent"],
```

鉴权相关头（`authorization`、`x-api-key` 等）仍然剥离，只额外放行 UA，不影响安全性。
